### PR TITLE
Add extraction of contact information for VM's and Devices.

### DIFF
--- a/netbox_prometheus_sd/__init__.py
+++ b/netbox_prometheus_sd/__init__.py
@@ -7,7 +7,7 @@ class PrometheusSD(PluginConfig):
     description = (
         "Provide Prometheus url_sd compatible API Endpoint with data from netbox"
     )
-    version = "0.1"
+    version = "0.4"
     author = "Felix Peters"
     author_email = "mail@felixpeters.de"
     base_url = "prometheus-sd"

--- a/netbox_prometheus_sd/api/serializers.py
+++ b/netbox_prometheus_sd/api/serializers.py
@@ -33,6 +33,7 @@ class PrometheusDeviceSerializer(serializers.ModelSerializer):
         utils.extract_tenant(obj, labels)
         utils.extract_cluster(obj, labels)
         utils.extract_services(obj, labels)
+        utils.extract_contacts(obj, labels)
 
         if hasattr(obj, "device_role") and obj.device_role is not None:
             labels["role"] = obj.device_role.name
@@ -73,6 +74,7 @@ class PrometheusVirtualMachineSerializer(serializers.ModelSerializer):
         utils.extract_tenant(obj, labels)
         utils.extract_cluster(obj, labels)
         utils.extract_services(obj, labels)
+        utils.extract_contacts(obj, labels)
 
         if hasattr(obj, "role") and obj.role is not None:
             labels["role"] = obj.role.name

--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -36,6 +36,8 @@ class VirtualMachineViewSet(
         "primary_ip6",
         "tags",
         "services",
+        "contacts",
+
     )
     filterset_class = VirtualMachineFilterSet
     serializer_class = PrometheusVirtualMachineSerializer


### PR DESCRIPTION
When a contactAssignment is created the plugin will now extract the following fields when they are populated.
If no value is present for email or role then the label will not be created.

            "__meta_netbox_contact_primary_name": "test contact",
            "__meta_netbox_contact_primary_email": "email@email.com",
            "__meta_netbox_contact_primary_comments": "comment",
            "__meta_netbox_contact_primary_role": "contact role",
            "__meta_netbox_contact_secondary_name": "Test Name 2",
            "__meta_netbox_contact_secondary_role": "contact role"

Have also bumped the plugin version as shown in Netbox to 0.4 as it was still 0.1. (on assumption it gets a bump)

I have not updated test cases as I cannot run them locally here to verify. Testing has been conducted against a running netbox instance and using to curl to verify plugin output. 