### PR TITLE
Allow complex fields in custom field labels

### DIFF
--- a/netbox_prometheus_sd/api/utils.py
+++ b/netbox_prometheus_sd/api/utils.py
@@ -1,5 +1,5 @@
+import json
 from netaddr import IPNetwork
-
 
 class LabelDict(dict):
     """Wrapper around dict to render labels"""
@@ -92,7 +92,9 @@ def extract_contacts(obj, labels: LabelDict):
 def extract_custom_fields(obj, labels: LabelDict):
     if hasattr(obj, "custom_field_data") and obj.custom_field_data is not None:
         for key, value in obj.custom_field_data.items():
-            if isinstance(value, (int, str, bool)):
+            # Render primitive value as string representation
+            if not hasattr(value, '__dict__'):
                 labels["custom_field_" + key.lower()] = str(value)
+            # Complex types are rendered as json
             else:
-                continue
+                labels["custom_field_" + key.lower()] = json.dumps(value)

--- a/netbox_prometheus_sd/tests/test_serializers.py
+++ b/netbox_prometheus_sd/tests/test_serializers.py
@@ -72,26 +72,29 @@ class PrometheusVirtualMachineSerializerTests(TestCase):
             {"__meta_netbox_primary_ip6": "2001:db8:1701::2"}, data["labels"]
         )
         self.assertDictContainsSubset(
-            {"__meta_netbox_custom_field_simple": "Foobar 123"}, data["labels"],
-            "Assert primitive custom field types are included in labels"
+            {"__meta_netbox_custom_field_simple": "Foobar 123"}, data["labels"]
         )
         self.assertDictContainsSubset(
-            {"__meta_netbox_custom_field_int": "42"}, data["labels"],
-            "Assert primitive custom field types are included in labels"
+            {"__meta_netbox_custom_field_int": "42"}, data["labels"]
         )
         self.assertDictContainsSubset(
-            {"__meta_netbox_custom_field_bool": "True"}, data["labels"],
-            "Assert primitive custom field types are included in labels"
+            {"__meta_netbox_custom_field_bool": "True"}, data["labels"]
         )
-        self.assertFalse(
-            "__meta_netbox_custom_field_multiple_choice" in data["labels"].keys(),
-            "Assert labels do not include multi choice fields"
+        self.assertDictContainsSubset(
+            {"__meta_netbox_custom_field_json": "{'foo': ['bar', 'baz']}"}, data["labels"]
         )
-        self.assertFalse(
-            "__meta_netbox_custom_field_complex" in data["labels"].keys(),
-            "Assert labels do not include complex fields"
+        self.assertDictContainsSubset(
+            {"__meta_netbox_custom_field_multi_selection": "['foo', 'baz']"}, data["labels"]
         )
-
+        self.assertDictContainsSubset(
+            {
+                "__meta_netbox_custom_field_contact":
+                "[{'id': 1, 'url': 'http://localhost:8000/api/tenancy/contacts/1/', 'display': 'Foo', 'name': 'Foo'}]"
+            }, data["labels"]
+        )
+        self.assertDictContainsSubset(
+            {"__meta_netbox_custom_field_text_long": "This is\r\na  pretty\r\nlog\r\nText"}, data["labels"]
+        )
 
 
 class PrometheusDeviceSerializerTests(TestCase):

--- a/netbox_prometheus_sd/tests/utils.py
+++ b/netbox_prometheus_sd/tests/utils.py
@@ -29,18 +29,28 @@ def build_tenant():
 def build_custom_fields():
     """Build custom field definition with different kinds of custom values"""
     return {
-        "simple": "Foobar 123",
-        "int": 42,
-        "bool": True,
-        "multi-choice": ["foo", "bar", "baz"],
-        "complex": [
+        "contact": [
             {
                 "id": 1,
-                "url": "https://demo.netbox.dev/api/tenancy/contacts/1/",
-                "display": "Bob",
-                "name": "Bob Bar"
+                "url": "http://localhost:8000/api/tenancy/contacts/1/",
+                "display": "Foo",
+                "name": "Foo"
             }
-        ]
+        ],
+        "json": {
+            "foo": [
+                "bar",
+                "baz"
+            ]
+        },
+        "multi_selection": [
+            "foo",
+            "baz"
+        ],
+        "simple": "Foobar 123",
+        "int": "42",
+        "text_long": "This is\r\na  pretty\r\nlog\r\nText",
+        "bool": "True"
     }
 
 def build_minimal_vm(name):


### PR DESCRIPTION
Follow up PR to #34 with complex fields serialized as string representation.

Requires some more testing with a real prometheus instance to make sure this works.
I really want to make sure not to break peoples service discovery with custom fields in labels.