### PR TITLE
Feature: add services API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Depending on the Netbox configuration, a token with valid object permissions mus
 ```
 GET        /api/plugins/prometheus-sd/devices/              Get a list of devices in a prometheus compatible format
 GET        /api/plugins/prometheus-sd/virtual-machines/     Get a list of vms in a prometheus compatible format
+GET        /api/plugins/prometheus-sd/services/             Get a list of services in a prometheus compatible format
 GET        /api/plugins/prometheus-sd/ip-addresses/         Get a list of ip in a prometheus compatible format
 ```
 

--- a/netbox_prometheus_sd/api/urls.py
+++ b/netbox_prometheus_sd/api/urls.py
@@ -1,7 +1,8 @@
 from rest_framework import routers
-from .views import VirtualMachineViewSet, DeviceViewSet, IPAddressViewSet
+from .views import VirtualMachineViewSet, DeviceViewSet, IPAddressViewSet, ServiceViewSet
 
 router = routers.DefaultRouter()
+router.register("services", ServiceViewSet)
 router.register("virtual-machines", VirtualMachineViewSet)
 router.register("devices", DeviceViewSet)
 router.register("ip-addresses", IPAddressViewSet)

--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -1,4 +1,4 @@
-from ipam.models import IPAddress
+from ipam.models import IPAddress, Service
 from virtualization.models import VirtualMachine
 from dcim.models.devices import Device
 
@@ -22,11 +22,11 @@ except ImportError:
 # Filtersets have been renamed, we support both
 # https://github.com/netbox-community/netbox/commit/1024782b9e0abb48f6da65f8248741227d53dbed#diff-d9224204dab475bbe888868c02235b8ef10f07c9201c45c90804d395dc161c40
 try:
-    from ipam.filtersets import IPAddressFilterSet
+    from ipam.filtersets import IPAddressFilterSet, ServiceFilterSet
     from dcim.filtersets import DeviceFilterSet
     from virtualization.filtersets import VirtualMachineFilterSet
 except ImportError:
-    from ipam.filters import IPAddressFilterSet
+    from ipam.filters import IPAddressFilterSet, ServiceFilterSet
     from dcim.filters import DeviceFilterSet
     from virtualization.filters import VirtualMachineFilterSet
 # pylint: enable=ungrouped-imports
@@ -36,7 +36,20 @@ from .serializers import (
     PrometheusIPAddressSerializer,
     PrometheusDeviceSerializer,
     PrometheusVirtualMachineSerializer,
+    PrometheusServiceSerializer
 )
+
+
+class ServiceViewSet(NetBoxModelViewSet):  # pylint: disable=too-many-ancestors
+    queryset = Service.objects.prefetch_related(
+        "device",
+        "virtual_machine",
+        "ipaddresses",
+        "tags",
+    )
+    filterset_class = ServiceFilterSet
+    serializer_class = PrometheusServiceSerializer
+    pagination_class = None
 
 
 

--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -40,7 +40,7 @@ from .serializers import (
 )
 
 
-class ServiceViewSet(NetBoxModelViewSet):  # pylint: disable=too-many-ancestors
+class ServiceViewSet(NetboxPrometheusSDModelViewSet):  # pylint: disable=too-many-ancestors
     queryset = Service.objects.prefetch_related(
         "device",
         "virtual_machine",
@@ -50,7 +50,6 @@ class ServiceViewSet(NetBoxModelViewSet):  # pylint: disable=too-many-ancestors
     filterset_class = ServiceFilterSet
     serializer_class = PrometheusServiceSerializer
     pagination_class = None
-
 
 
 class VirtualMachineViewSet(

--- a/netbox_prometheus_sd/tests/test_api.py
+++ b/netbox_prometheus_sd/tests/test_api.py
@@ -31,6 +31,9 @@ class ApiEndpointTests(TestCase):
             ContentType.objects.get(app_label="ipam", model="ipaddress")
         )
         obj_perm.object_types.add(  # pylint: disable=no-member
+            ContentType.objects.get(app_label="ipam", model="service")
+        )
+        obj_perm.object_types.add(  # pylint: disable=no-member
             ContentType.objects.get(app_label="virtualization", model="virtualmachine")
         )
         self.client.force_authenticate(user)
@@ -71,6 +74,20 @@ class ApiEndpointTests(TestCase):
             utils.build_full_ip(address=f"10.10.10.{i}/24")
 
         resp = self.client.get("/api/plugins/prometheus-sd/ip-addresses/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = json.loads(resp.content)
+
+        self.assertIsNotNone(data[0]["targets"])
+        self.assertIsNotNone(data[0]["labels"])
+        self.assertEqual(len(data), 60)
+
+    def test_endpoint_service(self):
+        """Ensure service endpoint returns a valid response"""
+
+        for i in range(60):
+            utils.build_vm_full(f"api-test-vm-{i}.example.com")
+
+        resp = self.client.get("/api/plugins/prometheus-sd/services/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = json.loads(resp.content)
 

--- a/netbox_prometheus_sd/tests/test_serializers.py
+++ b/netbox_prometheus_sd/tests/test_serializers.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from ..api.serializers import (
     PrometheusDeviceSerializer,
     PrometheusIPAddressSerializer,
+    PrometheusServiceSerializer,
     PrometheusVirtualMachineSerializer,
 )
 from . import utils
@@ -250,3 +251,44 @@ class PrometheusIPAddressSerializerTests(TestCase):
         self.assertDictContainsSubset(
             {"__meta_netbox_custom_field_simple": "Foobar 123"}, data["labels"]
         )
+
+
+class PrometheusServiceSerializerTests(TestCase):
+    def test_service_full_to_target(self):
+        vm = utils.build_vm_full("vm-full-01.example.com")
+        instance = vm.services.first()
+        data_list = PrometheusServiceSerializer(many=True, instance=[instance]).data
+
+        self.assertEqual(data_list[0]["targets"], ["ssh"])
+        for data in data_list:
+            self.assertDictContainsSubset({"__meta_netbox_id": str(instance.id)}, data["labels"])
+            self.assertDictContainsSubset(
+                {"__meta_netbox_display": "ssh (TCP/22)"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_ports": "22"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_parent": "vm-full-01.example.com"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_tenant": "Acme Corp."}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_tenant_slug": "acme"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_site": "Campus A"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_site_slug": "campus-a"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_primary_ip": "2001:db8:1701::2"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_primary_ip4": "192.168.0.1"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_primary_ip6": "2001:db8:1701::2"}, data["labels"]
+            )

--- a/netbox_prometheus_sd/tests/utils.py
+++ b/netbox_prometheus_sd/tests/utils.py
@@ -3,7 +3,7 @@ from dcim.models.sites import Site
 from dcim.models import Device, DeviceRole, Platform, Rack
 from extras.models import ConfigContext, Tag
 
-from ipam.models import IPAddress
+from ipam.models import IPAddress, Service
 from tenancy.models import Tenant, TenantGroup
 
 from virtualization.models import (
@@ -86,6 +86,8 @@ def build_vm_full(name):
 
     vm.tags.add("Tag1")
     vm.tags.add("Tag 2")
+
+    Service.objects.create(virtual_machine=vm, name="ssh", protocol='tcp', ports=[22])
     return vm
 
 


### PR DESCRIPTION
Adds a new API endpoint for Netbox Services https://docs.netbox.dev/en/stable/models/ipam/service/

```
GET   /api/plugins/prometheus-sd/services/   Get a list of services in a prometheus compatible format
```

I tried to follow the existing code style and conventions. I am open to any suggestions or changes. The specific labels I would appreciate a review on is `__meta_netbox_ipaddresses` and `__meta_netbox_ports`. IP address potentially may not be present. Both of these can be comma delimited strings, because as the docs say both can support multiple values:

> **Ports** -- One or more numeric ports to which the service is bound. Multiple ports can be expressed using commas and/or hyphens. For example, 80,8001-8003 specifies ports 80, 8001, 8002, and 8003.

> **IP Addresses** -- The [IP address(es)](https://docs.netbox.dev/en/stable/models/ipam/ipaddress/) to which this service is bound. If no IP addresses are bound, the service is assumed to be reachable via any assigned IP address.

That is the reason `__meta_netbox_primary_ip` from the parent (either device or virtual machine) is also included.

------------------

Example output:

```
GET /api/plugins/prometheus-sd/services/?tag=scrape-node

HTTP 200 OK
Allow: GET, POST, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

[
    {
        "targets": [
            "node-exporter"
        ],
        "labels": {
            "__meta_netbox_id": "37",
            "__meta_netbox_name": "node-exporter",
            "__meta_netbox_display": "node-exporter (TCP/9111)",
            "__meta_netbox_ipaddresses": "111.222.333.135",
            "__meta_netbox_ports": "9111",
            "__meta_netbox_tags": "Scrape Node",
            "__meta_netbox_tag_slugs": "scrape-node",
            "__meta_netbox_parent": "PHP-MYSQL-2",
            "__meta_netbox_primary_ip": "111.222.333.5",
            "__meta_netbox_primary_ip4": "111.222.333.5",
            "__meta_netbox_cluster": "2B",
            "__meta_netbox_cluster_type": "AvailabilityZone",
            "__meta_netbox_site": "US-WEST-2",
            "__meta_netbox_site_slug": "us-west-2",
            "__meta_netbox_custom_field_health_url": "None"
        }
    }
]```

