### PR TITLE
Add support to pickup prometheus-plugin-prometheus-sd config context

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,31 @@ GET        /api/plugins/prometheus-sd/virtual-machines/     Get a list of vms in
 GET        /api/plugins/prometheus-sd/ip-addresses/         Get a list of ip in a prometheus compatible format
 ```
 
+### Config context
+
+The plugin can also discover extra config to inject in the HTTP SD JSON from the config context of the devices/virtual machines.
+If you have a `prometheus-plugin-prometheus-sd` entry in your config context with the following schema it will be automatically picked up:
+
+```
+prometheus-plugin-prometheus-sd:
+  - metrics_path: /not/metrics
+    port: 4242
+    scheme: https
+  - port: 4243
+```
+
+This allow you to configure those values directly into netbox instead of doing that inside the Prometheus
+config and filtering each scenario by a specific tag for instance.
+
+If there is only one entry you can also use this form:
+
+```
+prometheus-plugin-prometheus-sd:
+  metrics_path: /not/metrics
+  port: 4242
+  scheme: https
+```
+
 ### Example
 
 A working example on how to use this plugin with Prometheus is located at the `example` folder. Netbox content is created by using Netbox docker initializers.

--- a/netbox_prometheus_sd/api/utils.py
+++ b/netbox_prometheus_sd/api/utils.py
@@ -103,3 +103,14 @@ def extract_custom_fields(obj, labels: LabelDict):
             # Complex types are rendered as json
             else:
                 labels["custom_field_" + key.lower()] = json.dumps(value)
+
+def extract_prometheus_sd_config(obj, labels):
+    prometheus_sd_config = getattr(obj, "_injected_prometheus_sd_config", {})
+
+    metrics_path = prometheus_sd_config.get("metrics_path", None)
+    if metrics_path and isinstance(metrics_path, str):
+        labels["__metrics__path__"] = metrics_path
+
+    scheme = prometheus_sd_config.get("scheme", None)
+    if scheme and isinstance(scheme, str):
+        labels["__scheme__"] = scheme

--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -2,17 +2,25 @@ from ipam.models import IPAddress
 from virtualization.models import VirtualMachine
 from dcim.models.devices import Device
 
-# The base ViewSet has been renamed, this try-except helps to support
-# Both < 3.2 and the newer 3.2+ Versions:
-# https://github.com/netbox-community/netbox/commit/bbdeae0ed9bcc06fb96ffa2970272e1a3447448c
-try:
-    from netbox.api.viewsets import NetBoxModelViewSet
+# pylint: disable=ungrouped-imports
+try:  # Netbox >= 3.5
+    from netbox.api.viewsets import BaseViewSet
+    from netbox.api.viewsets.mixins import CustomFieldsMixin
+    from rest_framework.mixins import ListModelMixin
+    # Netbox MosdelViewSet with list only
+    class NetboxPrometheusSDModelViewSet( # pylint: disable=too-many-ancestors
+        CustomFieldsMixin,
+        ListModelMixin,
+        BaseViewSet):
+        pass
 except ImportError:
-    from extras.api.views import CustomFieldModelViewSet as NetBoxModelViewSet
+    try: #  3.2 >= Netbox < 3.5
+        from netbox.api.viewsets import NetBoxModelViewSet as NetboxPrometheusSDModelViewSet
+    except ImportError: # Netbox < 3.2
+        from extras.api.views import CustomFieldModelViewSet as NetboxPrometheusSDModelViewSet
 
 # Filtersets have been renamed, we support both
 # https://github.com/netbox-community/netbox/commit/1024782b9e0abb48f6da65f8248741227d53dbed#diff-d9224204dab475bbe888868c02235b8ef10f07c9201c45c90804d395dc161c40
-# pylint: disable=ungrouped-imports
 try:
     from ipam.filtersets import IPAddressFilterSet
     from dcim.filtersets import DeviceFilterSet
@@ -31,8 +39,9 @@ from .serializers import (
 )
 
 
+
 class VirtualMachineViewSet(
-    NetBoxModelViewSet
+    NetboxPrometheusSDModelViewSet
 ):  # pylint: disable=too-many-ancestors
     queryset = VirtualMachine.objects.prefetch_related(
         "cluster__site",
@@ -51,7 +60,7 @@ class VirtualMachineViewSet(
     pagination_class = None
 
 
-class DeviceViewSet(NetBoxModelViewSet):  # pylint: disable=too-many-ancestors
+class DeviceViewSet(NetboxPrometheusSDModelViewSet):  # pylint: disable=too-many-ancestors
     queryset = Device.objects.prefetch_related(
         "device_type__manufacturer",
         "device_role",
@@ -71,7 +80,7 @@ class DeviceViewSet(NetBoxModelViewSet):  # pylint: disable=too-many-ancestors
     pagination_class = None
 
 
-class IPAddressViewSet(NetBoxModelViewSet):  # pylint: disable=too-many-ancestors
+class IPAddressViewSet(NetboxPrometheusSDModelViewSet):  # pylint: disable=too-many-ancestors
     queryset = IPAddress.objects.prefetch_related("tenant", "tags")
     serializer_class = PrometheusIPAddressSerializer
     filterset_class = IPAddressFilterSet

--- a/netbox_prometheus_sd/tests/test_api.py
+++ b/netbox_prometheus_sd/tests/test_api.py
@@ -61,7 +61,8 @@ class ApiEndpointTests(TestCase):
 
         self.assertIsNotNone(data[0]["targets"])
         self.assertIsNotNone(data[0]["labels"])
-        self.assertEqual(len(data), 60)
+        # Full vm contains two entry in the config context so we have to double the number of vm
+        self.assertEqual(len(data), 120)
 
     def test_endpoint_ip_address(self):
         """Ensure ip address endpoint returns a valid response"""

--- a/netbox_prometheus_sd/tests/test_serializers.py
+++ b/netbox_prometheus_sd/tests/test_serializers.py
@@ -12,7 +12,7 @@ class PrometheusVirtualMachineSerializerTests(TestCase):
     def test_vm_minimal_to_target(self):
 
         instance = utils.build_minimal_vm("vm-01.example.com")
-        data = PrometheusVirtualMachineSerializer(instance=instance).data
+        data = PrometheusVirtualMachineSerializer(many=True, instance=[instance]).data[0]
 
         self.assertEqual(data["targets"], ["vm-01.example.com"])
         self.assertDictContainsSubset({"__meta_netbox_id": str(instance.id)}, data["labels"])
@@ -32,82 +32,93 @@ class PrometheusVirtualMachineSerializerTests(TestCase):
 
     def test_vm_full_to_target(self):
         instance = utils.build_vm_full("vm-full-01.example.com")
-        data = PrometheusVirtualMachineSerializer(instance=instance).data
+        data_list = PrometheusVirtualMachineSerializer(many=True, instance=[instance]).data
 
-        self.assertEqual(data["targets"], ["vm-full-01.example.com"])
-        self.assertDictContainsSubset({"__meta_netbox_id": str(instance.id)}, data["labels"])
+        self.assertEqual(data_list[0]["targets"], ["vm-full-01.example.com:4242"])
         self.assertDictContainsSubset(
-            {"__meta_netbox_model": "VirtualMachine"}, data["labels"]
+            {"__metrics__path__": "/not/metrics"}, data_list[0]["labels"]
         )
         self.assertDictContainsSubset(
-            {"__meta_netbox_status": "active"}, data["labels"]
+            {"__scheme__": "https"}, data_list[0]["labels"]
         )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_tenant": "Acme Corp."}, data["labels"]
-        )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_tenant_slug": "acme"}, data["labels"]
-        )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_site": "Campus A"}, data["labels"]
-        )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_site_slug": "campus-a"}, data["labels"]
-        )
-        self.assertDictContainsSubset({"__meta_netbox_role": "VM"}, data["labels"])
-        self.assertDictContainsSubset({"__meta_netbox_role_slug": "vm"}, data["labels"])
-        self.assertDictContainsSubset(
-            {"__meta_netbox_platform": "Ubuntu 20.04"}, data["labels"]
-        )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_platform_slug": "ubuntu-20.04"}, data["labels"]
-        )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_primary_ip": "2001:db8:1701::2"}, data["labels"]
-        )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_primary_ip4": "192.168.0.1"}, data["labels"]
-        )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_primary_ip6": "2001:db8:1701::2"}, data["labels"]
-        )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_custom_field_simple": "Foobar 123"}, data["labels"]
-        )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_custom_field_int": "42"}, data["labels"]
-        )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_custom_field_bool": "True"}, data["labels"]
-        )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_custom_field_json": "{'foo': ['bar', 'baz']}"},
-            data["labels"],
-        )
-        self.assertDictContainsSubset(
-            {"__meta_netbox_custom_field_multi_selection": "['foo', 'baz']"},
-            data["labels"],
-        )
-        self.assertDictContainsSubset(
-            {
-                "__meta_netbox_custom_field_contact":
-                "[{'id': 1, 'url': 'http://localhost:8000/api/tenancy/contacts/1/', 'display': 'Foo', 'name': 'Foo'}]"
-            },
-            data["labels"],
-        )
-        self.assertDictContainsSubset(
-            {
-                "__meta_netbox_custom_field_text_long": "This is\r\na  pretty\r\nlog\r\nText"
-            },
-            data["labels"],
-        )
+        self.assertEqual(data_list[0]["targets"], ["vm-full-01.example.com:4242"])
+
+        self.assertEqual(data_list[1]["targets"], ["vm-full-01.example.com:4243"])
+        for data in data_list:
+            self.assertDictContainsSubset({"__meta_netbox_id": str(instance.id)}, data["labels"])
+            self.assertDictContainsSubset(
+                {"__meta_netbox_model": "VirtualMachine"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_status": "active"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_tenant": "Acme Corp."}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_tenant_slug": "acme"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_site": "Campus A"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_site_slug": "campus-a"}, data["labels"]
+            )
+            self.assertDictContainsSubset({"__meta_netbox_role": "VM"}, data["labels"])
+            self.assertDictContainsSubset({"__meta_netbox_role_slug": "vm"}, data["labels"])
+            self.assertDictContainsSubset(
+                {"__meta_netbox_platform": "Ubuntu 20.04"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_platform_slug": "ubuntu-20.04"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_primary_ip": "2001:db8:1701::2"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_primary_ip4": "192.168.0.1"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_primary_ip6": "2001:db8:1701::2"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_custom_field_simple": "Foobar 123"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_custom_field_int": "42"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_custom_field_bool": "True"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_custom_field_json": "{'foo': ['bar', 'baz']}"},
+                data["labels"],
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_custom_field_multi_selection": "['foo', 'baz']"},
+                data["labels"],
+            )
+            self.assertDictContainsSubset(
+                {
+                    "__meta_netbox_custom_field_contact":
+                    "[{'id': 1, 'url': 'http://localhost:8000/api/tenancy/contacts/1/',"
+                        + " 'display': 'Foo', 'name': 'Foo'}]"
+                },
+                data["labels"],
+            )
+            self.assertDictContainsSubset(
+                {
+                    "__meta_netbox_custom_field_text_long":
+                    "This is\r\na  pretty\r\nlog\r\nText"
+                },
+                data["labels"],
+            )
 
 
 class PrometheusDeviceSerializerTests(TestCase):
     def test_device_minimal_to_target(self):
-
         instance = utils.build_minimal_device("firewall-01")
-        data = PrometheusDeviceSerializer(instance=instance).data
+        data = PrometheusDeviceSerializer(many=True, instance=[instance]).data[0]
 
         self.assertEqual(data["targets"], ["firewall-01"])
         self.assertDictContainsSubset({"__meta_netbox_id": str(instance.id)}, data["labels"])
@@ -129,9 +140,33 @@ class PrometheusDeviceSerializerTests(TestCase):
             {"__meta_netbox_site_slug": "site"}, data["labels"]
         )
 
+    def test_device_config_context_no_array(self):
+        instance = utils.build_device_config_context_no_array("firewall-no-array-01")
+        data = PrometheusDeviceSerializer(many=True, instance=[instance]).data[0]
+
+        self.assertEqual(data["targets"], ["firewall-no-array-01:4242"])
+
+    def test_device_config_context_invalid_1(self):
+        instance = utils.build_device_config_context_invalid_1("firewall-invalid-01")
+        data = PrometheusDeviceSerializer(many=True, instance=[instance]).data[0]
+
+        self.assertEqual(data["targets"], ["firewall-invalid-01"])
+
+    def test_device_config_context_invalid_2(self):
+        instance = utils.build_device_config_context_invalid_2("firewall-invalid-02")
+        data = PrometheusDeviceSerializer(many=True, instance=[instance]).data[0]
+
+        self.assertEqual(data["targets"], ["firewall-invalid-02"])
+
+    def test_device_config_context_mix_valid_invalid(self):
+        instance = utils.build_device_config_context_mix_invalid_valid("firewall-valid-invalid-01")
+        data = PrometheusDeviceSerializer(many=True, instance=[instance]).data[0]
+
+        self.assertEqual(data["targets"], ["firewall-valid-invalid-01:4242"])
+
     def test_device_full_to_target(self):
         instance = utils.build_device_full("firewall-full-01")
-        data = PrometheusDeviceSerializer(instance=instance).data
+        data = PrometheusDeviceSerializer(many=True, instance=[instance]).data[0]
 
         self.assertEqual(data["targets"], ["firewall-full-01"])
         self.assertDictContainsSubset({"__meta_netbox_id": str(instance.id)}, data["labels"])
@@ -166,7 +201,7 @@ class PrometheusDeviceSerializerTests(TestCase):
 class PrometheusIPAddressSerializerTests(TestCase):
     def test_ip_minimal_to_target(self):
         instance = utils.build_minimal_ip("10.10.10.10/24")
-        data = PrometheusIPAddressSerializer(instance=instance).data
+        data = PrometheusIPAddressSerializer(many=True, instance=[instance]).data[0]
 
         self.assertEqual(data["targets"], ["10.10.10.10"])
         self.assertDictContainsSubset({"__meta_netbox_id": str(instance.id)}, data["labels"])
@@ -181,7 +216,7 @@ class PrometheusIPAddressSerializerTests(TestCase):
         instance = utils.build_full_ip(
             address="10.10.10.10/24", dns_name="foo.example.com"
         )
-        data = PrometheusIPAddressSerializer(instance=instance).data
+        data = PrometheusIPAddressSerializer(many=True, instance=[instance]).data[0]
 
         self.assertEqual(
             data["targets"],


### PR DESCRIPTION
## Describe your changes
Add the ability to automatically pickup config context with the following scheme:
```
prometheus-plugin-prometheus-sd:
  - metrics_path: /not/metrics
    port: 4242
    scheme: https
  - port: 4243
```

To do that I had add a custom list serializer to "duplicate" one entry to the number of entries of the array `prometheus-plugin-prometheus-sd` in the config context. The new serializer also inject a new variable that is used later on to the target and the labels.

Also add the ability in netbox >= 3.5 to restrict the API of this plugin to only list operations

## Issue ticket number and link
Fixes #120 
## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

