### PR TITLE
Use Device.role instead of Device.device_role where available (Netbox >=3.6.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           - v3.3.2
           - v3.4.4
           - v3.5.3
+          - v3.6.0
           - master
 
     steps:

--- a/netbox_prometheus_sd/api/serializers.py
+++ b/netbox_prometheus_sd/api/serializers.py
@@ -82,7 +82,10 @@ class PrometheusDeviceSerializer(serializers.ModelSerializer, PrometheusTargetsM
         utils.extract_rack(obj, labels)
         utils.extract_custom_fields(obj, labels)
 
-        if hasattr(obj, "device_role") and obj.device_role is not None:
+        if hasattr(obj, "role") and obj.role is not None:
+            labels["role"] = obj.role.name
+            labels["role_slug"] = obj.role.slug
+        elif hasattr(obj, "device_role") and obj.device_role is not None:  # netbox <3.6.0
             labels["role"] = obj.device_role.name
             labels["role_slug"] = obj.device_role.slug
 

--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -75,7 +75,7 @@ class VirtualMachineViewSet(
 class DeviceViewSet(NetboxPrometheusSDModelViewSet):  # pylint: disable=too-many-ancestors
     queryset = Device.objects.prefetch_related(
         "device_type__manufacturer",
-        "device_role",
+        "role" if hasattr(Device, "role") else "device_role",
         "tenant",
         "platform",
         "site",

--- a/netbox_prometheus_sd/tests/utils.py
+++ b/netbox_prometheus_sd/tests/utils.py
@@ -92,11 +92,9 @@ def build_vm_full(name):
 
 
 def build_minimal_device(name):
+    role_attr = "role" if hasattr(Device, "role") else "device_role"
     return Device.objects.get_or_create(
         name=name,
-        device_role=DeviceRole.objects.get_or_create(name="Firewall", slug="firewall")[
-            0
-        ],
         device_type=DeviceType.objects.get_or_create(
             model="SRX",
             slug="srx",
@@ -105,6 +103,9 @@ def build_minimal_device(name):
             )[0],
         )[0],
         site=Site.objects.get_or_create(name="Site", slug="site")[0],
+        **{
+            role_attr: DeviceRole.objects.get_or_create(name="Firewall", slug="firewall")[0],
+        }
     )[0]
 
 def build_device_config_context_no_array(name):


### PR DESCRIPTION
Fixes #132

## Describe your changes

Use Device.role with fallback to Device.device_role

## Issue ticket number and link

#132

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

I have applied the fix by hand to a Netbox v3.6.0 system and it works.  I have not tested with an earlier version of Netbox.

I have updated the tests so they *should* work with either device_role or role, but have not set up a test environment to check. (Ideally CI would check with multiple versions of Netbox)