### PR TITLE
Add site and site_slug labels to device services

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,16 @@ Netbox content should then be available in the service discovery tab.
 We use Poetry for dependency management and invoke as task runner.
 As Netbox plugins cannot be tested standalone, we need invoke to start all code embedded in Netbox Docker containers.
 
-All code to run in docker is located under `development`.
+All code to run in docker is located under `develop`.
 To start a virtual env managed by poetry run `poetry shell`.
 All following commands are started inside this environment.
 
 In order to run tests invoke the test steps
 
 ``` bash
+# Build Docker images
+invoke build
+
 # Execute all tests
 invoke tests
 

--- a/netbox_prometheus_sd/api/serializers.py
+++ b/netbox_prometheus_sd/api/serializers.py
@@ -96,10 +96,6 @@ class PrometheusDeviceSerializer(serializers.ModelSerializer, PrometheusTargetsM
             labels["device_type"] = obj.device_type.model
             labels["device_type_slug"] = obj.device_type.slug
 
-        if hasattr(obj, "site") and obj.site is not None:
-            labels["site"] = obj.site.name
-            labels["site_slug"] = obj.site.slug
-
         labels = labels.get_labels()
 
         # Those shouldn't have the netbox prefix

--- a/netbox_prometheus_sd/api/utils.py
+++ b/netbox_prometheus_sd/api/utils.py
@@ -62,6 +62,11 @@ def extract_cluster(obj, labels: LabelDict):
             labels["site"] = obj.cluster.site.name
             labels["site_slug"] = obj.cluster.site.slug
 
+    # Has precedence over cluster site
+    if hasattr(obj, "site") and obj.site is not None:
+        labels["site"] = obj.site.name
+        labels["site_slug"] = obj.site.slug
+
 
 def extract_primary_ip(obj, labels: LabelDict):
     if getattr(obj, "primary_ip", None) is not None:

--- a/netbox_prometheus_sd/tests/test_serializers.py
+++ b/netbox_prometheus_sd/tests/test_serializers.py
@@ -192,6 +192,12 @@ class PrometheusDeviceSerializerTests(TestCase):
         )
         self.assertDictContainsSubset({"__meta_netbox_rack": "R01B01"}, data["labels"])
         self.assertDictContainsSubset(
+            {"__meta_netbox_site": "Site"}, data["labels"]
+        )
+        self.assertDictContainsSubset(
+            {"__meta_netbox_site_slug": "site"}, data["labels"]
+        )
+        self.assertDictContainsSubset(
             {"__meta_netbox_description": "Device Description"}, data["labels"]
         )
         self.assertDictContainsSubset(
@@ -266,7 +272,46 @@ class PrometheusIPAddressSerializerTests(TestCase):
 
 
 class PrometheusServiceSerializerTests(TestCase):
-    def test_service_full_to_target(self):
+    def test_device_service_full_to_target(self):
+        device = utils.build_device_full("firewall-full-01")
+        instance = device.services.first()
+        data_list = PrometheusServiceSerializer(many=True, instance=[instance]).data
+
+        self.assertEqual(data_list[0]["targets"], ["ssh"])
+        for data in data_list:
+            self.assertDictContainsSubset({"__meta_netbox_id": str(instance.id)}, data["labels"])
+            self.assertDictContainsSubset(
+                {"__meta_netbox_display": "ssh (TCP/22)"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_ports": "22"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_parent": "firewall-full-01"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_tenant": "Acme Corp."}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_tenant_slug": "acme"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_site": "Site"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_site_slug": "site"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_primary_ip": "2001:db8:1701::2"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_primary_ip4": "192.168.0.1"}, data["labels"]
+            )
+            self.assertDictContainsSubset(
+                {"__meta_netbox_primary_ip6": "2001:db8:1701::2"}, data["labels"]
+            )
+
+    def test_vm_service_full_to_target(self):
         vm = utils.build_vm_full("vm-full-01.example.com")
         instance = vm.services.first()
         data_list = PrometheusServiceSerializer(many=True, instance=[instance]).data

--- a/netbox_prometheus_sd/tests/utils.py
+++ b/netbox_prometheus_sd/tests/utils.py
@@ -189,8 +189,11 @@ def build_device_full(name):
     device.rack = Rack.objects.get_or_create(
         name="R01B01", site=Site.objects.get_or_create(name="Site", slug="site")[0]
     )[0]
+    device.site = Site.objects.get_or_create(name="Site", slug="site")[0]
     device.tags.add("Tag1")
     device.tags.add("Tag 2")
+
+    Service.objects.create(device=device, name="ssh", protocol='tcp', ports=[22])
     return device
 
 


### PR DESCRIPTION
## Describe your changes

Hello,

when developing an internal Service Discovery framework I found out that Netbox devices do not necessarily have the _Site_ label present. When digging I found out that the condition applies only to devices without _Cluster_ set. I've made this PR to prioritize locally configured _Site_ of the device object, instead of _Rack_ or _Cluster_. Given how loose the constraints in Netbox database are, I might have missed something. Let me know please!

## Issue ticket number and link

None.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

