### PR TITLE
Proposal: Support tenant filtering in services

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ GET        /api/plugins/prometheus-sd/services/             Get a list of servic
 GET        /api/plugins/prometheus-sd/ip-addresses/         Get a list of ip in a prometheus compatible format
 ```
 
+#### Extended services filters
+
+Apart from standard Netbox filters, services endpoint also supports `tenant=<slug>` or `tenant_id=<id>` parameters.
+The lookup is only executed against the `tenant` attribute of the object associated with the service.
+
 ### Config context
 
 The plugin can also discover extra config to inject in the HTTP SD JSON from the config context of the devices/virtual machines.

--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -22,16 +22,17 @@ except ImportError:
 # Filtersets have been renamed, we support both
 # https://github.com/netbox-community/netbox/commit/1024782b9e0abb48f6da65f8248741227d53dbed#diff-d9224204dab475bbe888868c02235b8ef10f07c9201c45c90804d395dc161c40
 try:
-    from ipam.filtersets import IPAddressFilterSet, ServiceFilterSet
+    from ipam.filtersets import IPAddressFilterSet
     from dcim.filtersets import DeviceFilterSet
     from virtualization.filtersets import VirtualMachineFilterSet
 except ImportError:
-    from ipam.filters import IPAddressFilterSet, ServiceFilterSet
+    from ipam.filters import IPAddressFilterSet
     from dcim.filters import DeviceFilterSet
     from virtualization.filters import VirtualMachineFilterSet
 # pylint: enable=ungrouped-imports
 
 
+from ..filtersets import ServiceFilterSet
 from .serializers import (
     PrometheusIPAddressSerializer,
     PrometheusDeviceSerializer,

--- a/netbox_prometheus_sd/filtersets.py
+++ b/netbox_prometheus_sd/filtersets.py
@@ -1,0 +1,49 @@
+# Filtersets have been renamed, we support both
+# https://github.com/netbox-community/netbox/commit/1024782b9e0abb48f6da65f8248741227d53dbed#diff-d9224204dab475bbe888868c02235b8ef10f07c9201c45c90804d395dc161c40
+from django.db.models import Q
+from django.utils.translation import gettext as _
+
+from utilities.filters import MultiValueCharFilter, MultiValueNumberFilter
+
+try:
+    from ipam.filtersets import ServiceFilterSet as NetboxServiceFilterSet
+except ImportError:
+    from ipam.filters import ServiceFilterSet as NetboxServiceFilterSet
+
+
+class ServiceFilterSet(NetboxServiceFilterSet):
+    """Filter set to support tenancy over the device/VM foreign key.
+
+    Tenancy in Netbox is very incosistent and the relationship on its own is defined across many different models. This
+    means that supporting all layers is nearly impossible without a stronger upstream support. For this reason only the
+    "first level" tenancy is supported by this filter set.
+    """
+
+    tenant_id = MultiValueNumberFilter(
+        method='filter_by_tenant_id',
+        label=_('Tenant (ID)'),
+    )
+
+    tenant = MultiValueCharFilter(
+        method='filter_by_tenant_slug',
+        label=_('Tenant (slug)'),
+    )
+
+    # pylint: disable=unused-argument
+    def filter_by_cluster_tenant_id(self, queryset, name, value):
+        return queryset.filter(
+            Q(device__cluster__tenant_id__in=value) |
+            Q(virtual_machine__cluster__tenant_id__in=value)
+        )
+
+    def filter_by_cluster_tenant_slug(self, queryset, name, value):
+        return queryset.filter(
+            Q(device__cluster__tenant__slug__in=value) |
+            Q(virtual_machine__cluster__tenant__slug__in=value)
+        )
+
+    def filter_by_tenant_id(self, queryset, name, value):
+        return queryset.filter(Q(device__tenant_id__in=value) | Q(virtual_machine__tenant_id__in=value))
+
+    def filter_by_tenant_slug(self, queryset, name, value):
+        return queryset.filter(Q(device__tenant__slug__in=value) | Q(virtual_machine__tenant__slug__in=value))

--- a/netbox_prometheus_sd/tests/test_api.py
+++ b/netbox_prometheus_sd/tests/test_api.py
@@ -41,8 +41,8 @@ class ApiEndpointTests(TestCase):
     def test_endpoint_device(self):
         """Ensure device endpoint returns a valid response"""
 
-        for i in range(60):
-            utils.build_device_full(f"api-test-{i}.example.com")
+        for i in range(1, 61):
+            utils.build_device_full(f"api-test-{i}.example.com", i)
 
         resp = self.client.get("/api/plugins/prometheus-sd/devices/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
@@ -55,8 +55,8 @@ class ApiEndpointTests(TestCase):
     def test_endpoint_virtual_machine(self):
         """Ensure virtual machine endpoint returns a valid response"""
 
-        for i in range(60):
-            utils.build_vm_full(f"api-test-vm-{i}.example.com")
+        for i in range(1, 61):
+            utils.build_vm_full(f"api-test-vm-{i}.example.com", i)
 
         resp = self.client.get("/api/plugins/prometheus-sd/virtual-machines/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
@@ -70,7 +70,7 @@ class ApiEndpointTests(TestCase):
     def test_endpoint_ip_address(self):
         """Ensure ip address endpoint returns a valid response"""
 
-        for i in range(60):
+        for i in range(1, 61):
             utils.build_full_ip(address=f"10.10.10.{i}/24")
 
         resp = self.client.get("/api/plugins/prometheus-sd/ip-addresses/")
@@ -84,8 +84,8 @@ class ApiEndpointTests(TestCase):
     def test_endpoint_service(self):
         """Ensure service endpoint returns a valid response"""
 
-        for i in range(60):
-            utils.build_vm_full(f"api-test-vm-{i}.example.com")
+        for i in range(1, 61):
+            utils.build_vm_full(f"api-test-vm-{i}.example.com", i)
 
         resp = self.client.get("/api/plugins/prometheus-sd/services/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)

--- a/netbox_prometheus_sd/tests/test_filtersets.py
+++ b/netbox_prometheus_sd/tests/test_filtersets.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+
+from ipam.models import Service
+from tenancy.models import Tenant
+from utilities.testing import ChangeLoggedFilterSetTests
+
+from . import utils
+from ..filtersets import ServiceFilterSet
+
+
+class ServiceTestCase(TestCase, ChangeLoggedFilterSetTests):
+    queryset = Service.objects.all()
+    filterset = ServiceFilterSet
+
+    @classmethod
+    def setUpTestData(cls):
+        """Netbox requires us to define test data in this method, otherwise the ORM won't pick them.
+        """
+        for i in range(1, 4):
+            utils.build_device_full(f"firewall-full-0{i}", i)
+            utils.build_vm_full(f"vm-full-0{i}.example.com", i)
+
+    def test_device_tenant(self):
+        tenant = Tenant.objects.all()[0]
+
+        params = {'tenant_id': [tenant.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+        params = {'tenant': [tenant.slug]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+
+    def test_vm_tenant(self):
+        tenant = Tenant.objects.all()[0]
+
+        params = {'tenant_id': [tenant.pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+        params = {'tenant': [tenant.slug]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)

--- a/netbox_prometheus_sd/tests/utils.py
+++ b/netbox_prometheus_sd/tests/utils.py
@@ -65,7 +65,7 @@ def build_minimal_vm(name):
     return VirtualMachine.objects.get_or_create(name=name, cluster=build_cluster())[0]
 
 
-def build_vm_full(name):
+def build_vm_full(name, ip_octet=1):
     # Create the confix context beforehand
     config_context, created = ConfigContext.objects.get_or_create(name="context 1",
         weight=100, data={"prometheus-plugin-prometheus-sd": [
@@ -83,16 +83,16 @@ def build_vm_full(name):
     vm.platform = Platform.objects.get_or_create(
         name="Ubuntu 20.04", slug="ubuntu-20.04"
     )[0]
-    vm.save() # Save the platform so that we can find the config context in test API
 
     vm.tenant = build_tenant()
     vm.custom_field_data = build_custom_fields()
     vm.role = DeviceRole.objects.get_or_create(name="VM", slug="vm", vm_role=True)[0]
-    vm.primary_ip4 = IPAddress.objects.get_or_create(address="192.168.0.1/24")[0]
-    vm.primary_ip6 = IPAddress.objects.get_or_create(address="2001:db8:1701::2/64")[0]
+    vm.primary_ip4 = IPAddress.objects.get_or_create(address=f"192.168.0.{ip_octet}/24")[0]
+    vm.primary_ip6 = IPAddress.objects.get_or_create(address=f"2001:db8:1701::{ip_octet+1}/64")[0]
 
     vm.tags.add("Tag1")
     vm.tags.add("Tag 2")
+    vm.save()
 
     Service.objects.create(virtual_machine=vm, name="ssh", protocol='tcp', ports=[22])
     return vm
@@ -174,24 +174,23 @@ def build_device_config_context_mix_invalid_valid(name):
 
     return device
 
-def build_device_full(name):
+def build_device_full(name, ip_octet=1):
     device = build_minimal_device(name)
     device.location = build_location()
     device.tenant = build_tenant()
     device.description = "Device Description"
     device.custom_field_data = build_custom_fields()
     device.platform = Platform.objects.get_or_create(name="Junos", slug="junos")[0]
-    device.primary_ip4 = IPAddress.objects.get_or_create(address="192.168.0.1/24")[0]
-    device.primary_ip6 = IPAddress.objects.get_or_create(address="2001:db8:1701::2/64")[
-        0
-    ]
-    device.oob_ip = IPAddress.objects.get_or_create(address="10.0.0.1/24")[0]
+    device.primary_ip4 = IPAddress.objects.get_or_create(address=f"192.168.0.{ip_octet}/24")[0]
+    device.primary_ip6 = IPAddress.objects.get_or_create(address=f"2001:db8:1701::{ip_octet+1}/64")[0]
+    device.oob_ip = IPAddress.objects.get_or_create(address=f"10.0.0.{ip_octet}/24")[0]
     device.rack = Rack.objects.get_or_create(
         name="R01B01", site=Site.objects.get_or_create(name="Site", slug="site")[0]
     )[0]
     device.site = Site.objects.get_or_create(name="Site", slug="site")[0]
     device.tags.add("Tag1")
     device.tags.add("Tag 2")
+    device.save()
 
     Service.objects.create(device=device, name="ssh", protocol='tcp', ports=[22])
     return device
@@ -214,4 +213,6 @@ def build_full_ip(address, dns_name=""):
     ip.dns_name = dns_name
     ip.tags.add("Tag1")
     ip.tags.add("Tag 2")
+    ip.save()
+
     return ip


### PR DESCRIPTION
## Describe your changes
As I am building a full Prometheus service discovery based on Netbox's services, I stumbled upon an issue to be able to filter services by tenant. Netbox on its own doesn't support the tenant field in the views or filters of services, unlike for all other objects the SD plugin is available for, so I coded the support from scratch using a custom filterset.

Unfortunately tenancy in Netbox is very inconsistently assigned to objects with any sort of relation to the devices or VMs, such as clusters, cluster groups, sites, racks etc, so I decided to stay within the "one-FK away" distance from the service. When I was considering to go further (for example clusters) I wasn't able to come up with any consistent solution, which would also consider other objects, like IP addresses. IP addresses on the other hand are implemented entirely differently on the ORM side than services.

This change represents the minimal amount of work which makes the tenant filtering working for services, by introducing two filtering GET parameters `tenant=<slug>` and `tenant_id=<id>`. Not sure you will like this change, but we need it to be able to split discovered services to Prometheus instances owned by various teams without duplicating the tenancy structure through Netbox tags.

## Issue ticket number and link

None.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

