### PR TITLE
adding the ability to get the rack U position and feed it into labels.

### DIFF
--- a/netbox_prometheus_sd/api/serializers.py
+++ b/netbox_prometheus_sd/api/serializers.py
@@ -84,6 +84,7 @@ class PrometheusDeviceSerializer(serializers.ModelSerializer, PrometheusTargetsM
         utils.extract_contacts(obj, labels)
         utils.extract_rack(obj, labels)
         utils.extract_custom_fields(obj, labels)
+        utils.extract_rack_u_poistion(obj, labels)
 
         if hasattr(obj, "role") and obj.role is not None:
             labels["role"] = obj.role.name

--- a/netbox_prometheus_sd/api/utils.py
+++ b/netbox_prometheus_sd/api/utils.py
@@ -169,3 +169,8 @@ def extract_service_ports(obj, labels: LabelDict):
         and len(obj.ports)
     ):
         labels["ports"] = ",".join([str(port) for port in obj.ports])
+
+def extract_rack_u_poistion(obj, labels: LabelDict):
+    """Extract rack U poistion"""
+    if hasattr(obj, "position") and obj.position:
+        labels["rack_u_position"] = obj.position

--- a/netbox_prometheus_sd/tests/test_serializers.py
+++ b/netbox_prometheus_sd/tests/test_serializers.py
@@ -215,6 +215,9 @@ class PrometheusDeviceSerializerTests(TestCase):
         self.assertDictContainsSubset(
             {"__meta_netbox_custom_field_simple": "Foobar 123"}, data["labels"]
         )
+        self.assertDictContainsSubset(
+            {"__meta_netbox_rack_u_position": "1.0"}, data["labels"]
+        )
 
 
 class PrometheusIPAddressSerializerTests(TestCase):

--- a/netbox_prometheus_sd/tests/utils.py
+++ b/netbox_prometheus_sd/tests/utils.py
@@ -191,7 +191,7 @@ def build_device_full(name, ip_octet=1):
     device.tags.add("Tag1")
     device.tags.add("Tag 2")
     device.save()
-
+    device.position = "1.0"
     Service.objects.create(device=device, name="ssh", protocol='tcp', ports=[22])
     return device
 


### PR DESCRIPTION
## Describe your changes
This allows you to return the RACK U from a racked physical device into a label to be used in alerting or grafana.

## Issue ticket number and link

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
