### PR TITLE
Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ GET        /api/plugins/prometheus-sd/devices/              Get a list of device
 GET        /api/plugins/prometheus-sd/virtual-machines/     Get a list of vms in a prometheus compatible format
 GET        /api/plugins/prometheus-sd/services/             Get a list of services in a prometheus compatible format
 GET        /api/plugins/prometheus-sd/ip-addresses/         Get a list of ip in a prometheus compatible format
+GET        /api/plugins/prometheus-sd/interfaces/           Get a list of interfaces in a prometheus compatible format
 ```
 
 #### Extended services filters

--- a/netbox_prometheus_sd/api/serializers.py
+++ b/netbox_prometheus_sd/api/serializers.py
@@ -10,7 +10,6 @@ from netaddr import IPNetwork
 from .utils import LabelDict
 from . import utils
 
-
 class SDConfigContextDuplicateSerializer(serializers.ListSerializer):
 
     def update(self, instance, validated_data):

--- a/netbox_prometheus_sd/api/urls.py
+++ b/netbox_prometheus_sd/api/urls.py
@@ -4,6 +4,7 @@ from .views import (
     DeviceViewSet,
     IPAddressViewSet,
     ServiceViewSet,
+    InterfaceViewSet
 )
 
 router = routers.DefaultRouter()
@@ -11,5 +12,6 @@ router.register("services", ServiceViewSet)
 router.register("virtual-machines", VirtualMachineViewSet)
 router.register("devices", DeviceViewSet)
 router.register("ip-addresses", IPAddressViewSet)
+router.register("interfaces", InterfaceViewSet)
 
 urlpatterns = router.urls

--- a/netbox_prometheus_sd/api/utils.py
+++ b/netbox_prometheus_sd/api/utils.py
@@ -1,7 +1,6 @@
 import json
 from netaddr import IPNetwork
 
-
 class LabelDict(dict):
     """Wrapper around dict to render labels"""
 

--- a/netbox_prometheus_sd/api/utils.py
+++ b/netbox_prometheus_sd/api/utils.py
@@ -20,6 +20,12 @@ class LabelDict(dict):
             for key, val in self.items()
         }
 
+    def get_parent_labels(self):
+        """Prefix and replace invalid key chars for prometheus labels"""
+        return {
+            "__meta_netbox_parent_" + str(self.promsafestr(key)): val
+            for key, val in self.items()
+        }
 
 def extract_description(obj, labels: LabelDict):
     """Extract description"""

--- a/netbox_prometheus_sd/api/utils.py
+++ b/netbox_prometheus_sd/api/utils.py
@@ -20,13 +20,6 @@ class LabelDict(dict):
             for key, val in self.items()
         }
 
-    def get_parent_labels(self):
-        """Prefix and replace invalid key chars for prometheus labels"""
-        return {
-            "__meta_netbox_parent_" + str(self.promsafestr(key)): val
-            for key, val in self.items()
-        }
-
 def extract_description(obj, labels: LabelDict):
     """Extract description"""
     if hasattr(obj, "description") and obj.description:

--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -2,7 +2,6 @@ from ipam.models import IPAddress, Service
 from virtualization.models import VirtualMachine
 from dcim.models.devices import Device, Interface
 
-
 try:  # Netbox >= 3.5
     from netbox.api.viewsets import BaseViewSet
     from netbox.api.viewsets.mixins import CustomFieldsMixin


### PR DESCRIPTION
## Describe your changes

Add API for Interfaces.  Allows for using a specific interface (ip) instead of entire device and therefore could monitor multiple interfaces of a box rather than a single primary address. Also grabs parent device custom fields to reduce redundancy of information needing to be stored at each level.

## Issue ticket number and link

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
