### PR TITLE
feat: override target with host from netbox custom config data

### DIFF
--- a/netbox_prometheus_sd/api/serializers.py
+++ b/netbox_prometheus_sd/api/serializers.py
@@ -36,6 +36,7 @@ class SDConfigContextDuplicateSerializer(serializers.ListSerializer):
                     "port" not in prometheus_sd_config
                     and "metrics_path" not in prometheus_sd_config
                     and "scheme" not in prometheus_sd_config
+                    and "host" not in prometheus_sd_config
                 ):
                     continue
 
@@ -50,8 +51,8 @@ class SDConfigContextDuplicateSerializer(serializers.ListSerializer):
 
 class PrometheusTargetsMixin:
     def get_targets(self, obj):
-        target = obj.name
         prometheus_sd_config = getattr(obj, "_injected_prometheus_sd_config", {})
+        target = prometheus_sd_config.get("host", obj.name)
 
         port = prometheus_sd_config.get("port", None)
         if port and isinstance(port, int):

--- a/netbox_prometheus_sd/tests/test_api.py
+++ b/netbox_prometheus_sd/tests/test_api.py
@@ -70,8 +70,8 @@ class ApiEndpointTests(TestCase):
 
         self.assertIsNotNone(data[0]["targets"])
         self.assertIsNotNone(data[0]["labels"])
-        # Full vm contains two entry in the config context so we have to double the number of vm
-        self.assertEqual(len(data), 120)
+        # Full vm contains three entry in the config context so we have to triple the number of vm
+        self.assertEqual(len(data), 180)
 
     def test_endpoint_ip_address(self):
         """Ensure ip address endpoint returns a valid response"""

--- a/netbox_prometheus_sd/tests/test_serializers.py
+++ b/netbox_prometheus_sd/tests/test_serializers.py
@@ -63,6 +63,8 @@ class PrometheusVirtualMachineSerializerTests(TestCase):
         self.assertEqual(data_list[0]["targets"], ["vm-full-01.example.com:4242"])
 
         self.assertEqual(data_list[1]["targets"], ["vm-full-01.example.com:4243"])
+
+        self.assertEqual(data_list[2]["targets"], ["another.host.xyz:4244"])
         for data in data_list:
             self.assertTrue(
                 utils.dictContainsSubset(

--- a/netbox_prometheus_sd/tests/utils.py
+++ b/netbox_prometheus_sd/tests/utils.py
@@ -86,6 +86,7 @@ def build_vm_full(name, ip_octet=1):
             "prometheus-plugin-prometheus-sd": [
                 {"metrics_path": "/not/metrics", "port": 4242, "scheme": "https"},
                 {"port": 4243},
+                {"host": f"another.host.xyz", "port": 4244},
             ]
         },
     )


### PR DESCRIPTION
## Describe your changes
Added "host" config option to netbox config context. Analogue to the "port" option, the value set will be used for the "__address__" label. Setting an explicit host is useful if the prometheus exporter only listens on a single interface or vhost.

## Issue ticket number and link
-

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
