### PR TITLE
fix: return device's primary ip for netbox services not explicitly bound to any IP

### DIFF
--- a/netbox_prometheus_sd/api/utils.py
+++ b/netbox_prometheus_sd/api/utils.py
@@ -179,6 +179,8 @@ def extract_service_ips(obj, labels: LabelDict):
         labels["ipaddresses"] = ",".join(
             [str(ipaddr.address.ip) for ipaddr in obj.ipaddresses.all()]
         )
+    elif hasattr(obj.parent, "primary_ip") and obj.parent.primary_ip is not None:
+        labels["ipaddresses"] = str(IPNetwork(obj.parent.primary_ip.address).ip)
 
 
 def extract_service_ports(obj, labels: LabelDict):

--- a/netbox_prometheus_sd/tests/test_serializers.py
+++ b/netbox_prometheus_sd/tests/test_serializers.py
@@ -493,6 +493,11 @@ class PrometheusServiceSerializerTests(TestCase):
                     {"__meta_netbox_primary_ip6": "2001:db8:1701::2"}, data["labels"]
                 )
             )
+            self.assertTrue(
+                utils.dictContainsSubset(
+                    {"__meta_netbox_ipaddresses": "2001:db8:1701::2"}, data["labels"]
+                )
+            )
 
     def test_vm_service_full_to_target(self):
         vm = utils.build_vm_full("vm-full-01.example.com")
@@ -574,5 +579,10 @@ class PrometheusServiceSerializerTests(TestCase):
             self.assertTrue(
                 utils.dictContainsSubset(
                     {"__meta_netbox_primary_ip6": "2001:db8:1701::2"}, data["labels"]
+                )
+            )
+            self.assertTrue(
+                utils.dictContainsSubset(
+                    {"__meta_netbox_ipaddresses": "2001:db8:1701::2"}, data["labels"]
                 )
             )


### PR DESCRIPTION
## Describe your changes
When a service has no explicit IP set, the "ipaddresses" label will not be set. A service with no explicit IP set will probably listen on all interfaces, so the primary IP should be returned. That way, "ipaddresses" can be used to get a valid IP to connect to that service regardless of configuration.

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
