### PR TITLE
feat: add params dict to custom config options that will be used as __param_ labels

### DIFF
--- a/netbox_prometheus_sd/api/serializers.py
+++ b/netbox_prometheus_sd/api/serializers.py
@@ -36,6 +36,7 @@ class SDConfigContextDuplicateSerializer(serializers.ListSerializer):
                     "port" not in prometheus_sd_config
                     and "metrics_path" not in prometheus_sd_config
                     and "scheme" not in prometheus_sd_config
+                    and "params" not in prometheus_sd_config
                 ):
                     continue
 

--- a/netbox_prometheus_sd/api/utils.py
+++ b/netbox_prometheus_sd/api/utils.py
@@ -160,6 +160,14 @@ def extract_prometheus_sd_config(obj, labels):
     if scheme and isinstance(scheme, str):
         labels["__scheme__"] = scheme
 
+    params = prometheus_sd_config.get("params", None)
+    if params and isinstance(params, dict):
+        for key, value in params.items():
+            if isinstance(value, list):
+                labels[f"__param_{key}"] = ",".join(value)
+            else:
+                labels[f"__param_{key}"] = str(value)
+
 
 def extract_parent(obj, labels: LabelDict):
     labels["parent"] = obj.parent.name

--- a/netbox_prometheus_sd/tests/test_serializers.py
+++ b/netbox_prometheus_sd/tests/test_serializers.py
@@ -63,6 +63,14 @@ class PrometheusVirtualMachineSerializerTests(TestCase):
         self.assertEqual(data_list[0]["targets"], ["vm-full-01.example.com:4242"])
 
         self.assertEqual(data_list[1]["targets"], ["vm-full-01.example.com:4243"])
+        self.assertTrue(
+            utils.dictContainsSubset(
+                {
+                    "__param_target": "other.host.xyz",
+                },
+                data_list[1]["labels"],
+            )
+        )
         for data in data_list:
             self.assertTrue(
                 utils.dictContainsSubset(

--- a/netbox_prometheus_sd/tests/utils.py
+++ b/netbox_prometheus_sd/tests/utils.py
@@ -85,7 +85,7 @@ def build_vm_full(name, ip_octet=1):
         data={
             "prometheus-plugin-prometheus-sd": [
                 {"metrics_path": "/not/metrics", "port": 4242, "scheme": "https"},
-                {"port": 4243},
+                {"port": 4243, "params": {"target": "other.host.xyz"}},
             ]
         },
     )


### PR DESCRIPTION
## Describe your changes
When adding "\_\_param\_*" labels to a discovered endpoint, the params will not only be available for relabeling, but also added to the scrape request as GET params. Indirect exporters, e.g. the blackhole exporter, use a "target" param to select the probed host.

Btw: Adding the param to the "\_\_address\_\_" label does not work due to url-encoding.

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
