### PR TITLE
feat: add custom_config label to indicate which options where customized in config context

### DIFF
--- a/netbox_prometheus_sd/api/utils.py
+++ b/netbox_prometheus_sd/api/utils.py
@@ -150,7 +150,11 @@ def extract_custom_fields(obj, labels: LabelDict):
 
 
 def extract_prometheus_sd_config(obj, labels):
-    prometheus_sd_config = getattr(obj, "_injected_prometheus_sd_config", {})
+    prometheus_sd_config = getattr(obj, "_injected_prometheus_sd_config", None)
+    if not prometheus_sd_config:
+        return
+
+    labels["__meta_netbox_custom_config"] = ",".join(prometheus_sd_config.keys())
 
     metrics_path = prometheus_sd_config.get("metrics_path", None)
     if metrics_path and isinstance(metrics_path, str):

--- a/netbox_prometheus_sd/tests/test_serializers.py
+++ b/netbox_prometheus_sd/tests/test_serializers.py
@@ -1,3 +1,5 @@
+from itertools import permutations
+
 from django.test import TestCase
 from ..api.serializers import (
     PrometheusDeviceSerializer,
@@ -61,6 +63,17 @@ class PrometheusVirtualMachineSerializerTests(TestCase):
             utils.dictContainsSubset({"__scheme__": "https"}, data_list[0]["labels"])
         )
         self.assertEqual(data_list[0]["targets"], ["vm-full-01.example.com:4242"])
+        self.assertTrue(
+            any(
+                utils.dictContainsSubset(
+                    {
+                        "__meta_netbox_custom_config": ",".join(p),
+                    },
+                    data_list[0]["labels"],
+                )
+                for p in permutations(['metrics_path', 'port', 'scheme'])
+            )
+        )
 
         self.assertEqual(data_list[1]["targets"], ["vm-full-01.example.com:4243"])
         for data in data_list:


### PR DESCRIPTION
## Describe your changes
I needed a label to filter for devices that have set a configuration context, as I want to monitor only devices that have an exporter specified.

This could have been a simple boolean value for my case, but I implemented a comma-separated list of keys specified. I think it may be useful during relabeling.

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
