### PR TITLE
fix: annotate config context data on device/vm query sets

### DIFF
--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -60,7 +60,7 @@ class VirtualMachineViewSet(NetboxPrometheusSDModelViewSet):
         "tags",
         "services",
         "contacts",
-    )
+    ).annotate_config_context_data()
     filterset_class = VirtualMachineFilterSet
     serializer_class = PrometheusVirtualMachineSerializer
     pagination_class = None
@@ -80,7 +80,7 @@ class DeviceViewSet(NetboxPrometheusSDModelViewSet):
         "primary_ip4__nat_outside",
         "primary_ip6__nat_outside",
         "tags",
-    )
+    ).annotate_config_context_data()
     filterset_class = DeviceFilterSet
     serializer_class = PrometheusDeviceSerializer
     pagination_class = None


### PR DESCRIPTION
## Describe your changes

Added a `.annotate_config_context_data()` call from `ConfigContextModelQuerySet` onto the `Device` and `VirtualMachine` query sets. This performs JSON aggregation in the database, so `ConfigContextModel` doesn't hit the database every time `.get_config_context()` is called (so for every row in the result set).

This speeds up the views by ~5-6x (`/devices` in particular, in our case).

## Issue ticket number and link

—

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
