### PR TITLE
fix: related query set fixes

### DIFF
--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -60,7 +60,7 @@ class VirtualMachineViewSet(NetboxPrometheusSDModelViewSet):
         "tags",
         "services",
         "contacts",
-    )
+    ).annotate_config_context_data()
     filterset_class = VirtualMachineFilterSet
     serializer_class = PrometheusVirtualMachineSerializer
     pagination_class = None
@@ -80,7 +80,7 @@ class DeviceViewSet(NetboxPrometheusSDModelViewSet):
         "primary_ip4__nat_outside",
         "primary_ip6__nat_outside",
         "tags",
-    )
+    ).annotate_config_context_data()
     filterset_class = DeviceFilterSet
     serializer_class = PrometheusDeviceSerializer
     pagination_class = None

--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -54,16 +54,19 @@ class VirtualMachineViewSet(NetboxPrometheusSDModelViewSet):
     queryset = (
         VirtualMachine.objects.select_related(
             "role",
-            "tenant",
+            "tenant__group",
             "platform",
             "primary_ip4",
             "primary_ip6",
         )
         .prefetch_related(
             cluster_scope,
+            "cluster__group",
+            "cluster__type",
             "tags",
             "services",
-            "contacts",
+            "contacts__contact",
+            "contacts__role",
         )
         .annotate_config_context_data()
     )
@@ -77,18 +80,22 @@ class DeviceViewSet(NetboxPrometheusSDModelViewSet):
         Device.objects.select_related(
             "device_type__manufacturer",
             "role" if hasattr(Device, "role") else "device_role",
-            "tenant",
+            "tenant__group",
             "platform",
             "site",
             "location",
             "rack",
             "parent_bay",
             "virtual_chassis__master",
+            "oob_ip",
         )
         .prefetch_related(
             "primary_ip4__nat_outside",
             "primary_ip6__nat_outside",
             "tags",
+            "services",
+            "contacts__contact",
+            "contacts__role",
         )
         .annotate_config_context_data()
     )
@@ -98,7 +105,9 @@ class DeviceViewSet(NetboxPrometheusSDModelViewSet):
 
 
 class IPAddressViewSet(NetboxPrometheusSDModelViewSet):
-    queryset = IPAddress.objects.select_related("tenant").prefetch_related("tags")
+    queryset = IPAddress.objects.select_related("tenant__group").prefetch_related(
+        "tags"
+    )
     serializer_class = PrometheusIPAddressSerializer
     filterset_class = IPAddressFilterSet
     pagination_class = None

--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -34,9 +34,10 @@ class NetboxPrometheusSDModelViewSet(CustomFieldsMixin, ListModelMixin, BaseView
 
 
 class ServiceViewSet(NetboxPrometheusSDModelViewSet):
-    queryset = Service.objects.prefetch_related(
+    queryset = Service.objects.select_related(
         "device",
         "virtual_machine",
+    ).prefetch_related(
         "ipaddresses",
         "tags",
     )
@@ -50,44 +51,54 @@ class VirtualMachineViewSet(NetboxPrometheusSDModelViewSet):
         cluster_scope = "cluster__scope"
     else:
         cluster_scope = "cluster__site"
-    queryset = VirtualMachine.objects.prefetch_related(
-        cluster_scope,
-        "role",
-        "tenant",
-        "platform",
-        "primary_ip4",
-        "primary_ip6",
-        "tags",
-        "services",
-        "contacts",
-    ).annotate_config_context_data()
+    queryset = (
+        VirtualMachine.objects.select_related(
+            "role",
+            "tenant",
+            "platform",
+            "primary_ip4",
+            "primary_ip6",
+        )
+        .prefetch_related(
+            cluster_scope,
+            "tags",
+            "services",
+            "contacts",
+        )
+        .annotate_config_context_data()
+    )
     filterset_class = VirtualMachineFilterSet
     serializer_class = PrometheusVirtualMachineSerializer
     pagination_class = None
 
 
 class DeviceViewSet(NetboxPrometheusSDModelViewSet):
-    queryset = Device.objects.prefetch_related(
-        "device_type__manufacturer",
-        "role" if hasattr(Device, "role") else "device_role",
-        "tenant",
-        "platform",
-        "site",
-        "location",
-        "rack",
-        "parent_bay",
-        "virtual_chassis__master",
-        "primary_ip4__nat_outside",
-        "primary_ip6__nat_outside",
-        "tags",
-    ).annotate_config_context_data()
+    queryset = (
+        Device.objects.select_related(
+            "device_type__manufacturer",
+            "role" if hasattr(Device, "role") else "device_role",
+            "tenant",
+            "platform",
+            "site",
+            "location",
+            "rack",
+            "parent_bay",
+            "virtual_chassis__master",
+        )
+        .prefetch_related(
+            "primary_ip4__nat_outside",
+            "primary_ip6__nat_outside",
+            "tags",
+        )
+        .annotate_config_context_data()
+    )
     filterset_class = DeviceFilterSet
     serializer_class = PrometheusDeviceSerializer
     pagination_class = None
 
 
 class IPAddressViewSet(NetboxPrometheusSDModelViewSet):
-    queryset = IPAddress.objects.prefetch_related("tenant", "tags")
+    queryset = IPAddress.objects.select_related("tenant").prefetch_related("tags")
     serializer_class = PrometheusIPAddressSerializer
     filterset_class = IPAddressFilterSet
     pagination_class = None


### PR DESCRIPTION
## Describe your changes

Updates the query sets to use `.select_related` (SQL join) where possible, and `.prefetch_related` (+1 query for each and join in Python) for reverse/m2m relations only. Additionally, there were some missing relations, which are used in various functions in `utils.py`.

In conjunction with https://github.com/FlxPeters/netbox-plugin-prometheus-sd/pull/254 (this branch also includes the changes from that one), the speedup on the `/devices` endpoint is around ~11-12x.

## Issue ticket number and link

—

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
