### PR TITLE
fix: eliminate N+1 queries on service discovery endpoints (#265)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 .pyre/
 
 node_modules/
+
+# Claude Code local config
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,122 @@
+# AGENTS.md
+
+## What this is
+
+A NetBox plugin that exposes devices, virtual machines, services, and IP addresses
+through a Prometheus HTTP service discovery (`http_sd`) compatible API.
+
+## Design principle: reuse NetBox, don't reimplement it
+
+The plugin is a thin layer on top of NetBox's own REST API stack:
+
+- `netbox_prometheus_sd/api/views.py` reuses NetBox's own ViewSets, filtersets, and
+  querysets (`Device.objects`, `VirtualMachine.objects`, `Service.objects`,
+  `IPAddress.objects`) instead of defining new views or filtering logic. Any filter
+  that works on the core NetBox API also works on these endpoints.
+- `netbox_prometheus_sd/api/serializers.py` adds Prometheus-shaped serializers
+  (`targets` + `labels`) on top of those querysets — this is the only real "new"
+  layer the plugin owns.
+- `netbox_prometheus_sd/api/utils.py` holds small `extract_*(obj, labels)` helpers,
+  one per label group (tenant, cluster, tags, contacts, custom fields, ...), shared
+  across the Device/VM/Service/IPAddress serializers.
+- `netbox_prometheus_sd/filtersets.py` is the one deliberate exception: it subclasses
+  NetBox's `ServiceFilterSet` to add first-level tenancy filtering, which core
+  NetBox doesn't offer for services.
+- Pagination is disabled on all endpoints (`pagination_class = None`) because
+  Prometheus expects the full target list in one response.
+- Auth/permissions are NetBox's own object-permission model — no plugin-specific
+  auth.
+
+## NetBox version compatibility
+
+The plugin supports the NetBox `4.x` line only (see `.github/workflows/ci.yml` for
+the tested matrix). NetBox `3.x` is not supported and new `3.x` fallback code
+should not be added.
+
+NetBox's models still change between 4.x minors, so compatibility within the line
+is handled two ways:
+
+- **At class-definition time** (queryset construction), via the parsed-version
+  constants in `api/utils.py` (`NETBOX_RELEASE_CURRENT`, `NETBOX_RELEASE_41`, ...)
+  or a field-existence check.
+- **At runtime** (label extraction), via `try`/`except AttributeError`/`FieldError`
+  in the `extract_*` helpers and test fixtures.
+
+Known differences that are already shimmed:
+
+- `Cluster.site` became a generic `scope` relation in 4.2 — `extract_cluster()`
+  emits `scope`/`scope_slug` labels on 4.2+ and `site`/`site_slug` below that;
+  the queryset path differs too (`cluster__scope` vs `cluster__site`).
+- `Service.device`/`Service.virtual_machine` became a single generic
+  `Service.parent` in 4.3.
+
+Detecting 4.3+ deserves a warning: **`hasattr(Service, "device")` is always true
+on every NetBox version** and cannot be used as the check. Device and
+VirtualMachine declare `services = GenericRelation(..., related_query_name=...)`,
+so `Service.device` always resolves to a read-only reverse accessor. Check
+`hasattr(Service, "parent_object_type")` instead, which only exists once `parent`
+is a real GenericForeignKey.
+
+When touching model field access, assume any 4.x release may hit the code path,
+and check field existence rather than assuming a version.
+
+## Performance
+
+Because pagination is off, a single request serializes the entire device/VM/
+service/IP inventory. Query efficiency dominates response time here — an
+unprefetched relation touched inside a serializer's `get_labels()` becomes an N+1
+across every row, which is what made these endpoints take minutes on real
+inventories (issue #265).
+
+Rules of thumb when editing `views.py`:
+
+- Adding a label that reads a related object means adding the matching
+  `select_related` (single-valued FKs, one JOIN) or `prefetch_related`
+  (reverse/m2m/generic relations, one extra query).
+- `Device`/`VirtualMachine` querysets must keep `.annotate_config_context_data()`.
+  Without it, `get_config_context()` — called for every row by
+  `SDConfigContextDuplicateSerializer` — issues a query per row.
+- A GenericForeignKey (`cluster__scope`, `Service.parent`) cannot be
+  `select_related`; use `prefetch_related` / `GenericPrefetch`.
+
+## Testing
+
+NetBox plugins can't be tested standalone. Tests are Django unit tests
+(`netbox_prometheus_sd/tests/`) executed inside a real NetBox container, spun up
+by [testcontainers](https://testcontainers.com/?language=python) from `tasks.py`.
+The same tests run locally and in CI — there is no separate integration layer.
+
+```bash
+invoke test        # build the image and run the whole suite
+invoke build_dev   # start a dev NetBox on http://localhost:8000 and keep it up
+```
+
+`NETBOX_VER` selects the NetBox image tag (default `latest`), e.g.
+`NETBOX_VER=v4.6.5 invoke test`. Each run builds a throwaway container, so
+switching versions needs no manual cleanup.
+
+Note that `assertDictContainsSubset` was removed from `unittest` in Python 3.12;
+`tests/utils.py` provides a `dictContainsSubset(subset, fullset)` helper instead.
+
+Every feature or fix needs a test. Fixtures live in
+`netbox_prometheus_sd/tests/utils.py` (`build_device_full`, `build_vm_full`, ...)
+and should be extended rather than duplicated. Fixture builders that persist
+objects take an `ip_octet` argument — pass a unique value per object when a test
+creates several, since `primary_ip4`/`primary_ip6` are unique one-to-one fields.
+
+## Commits and releases
+
+This repository follows Conventional Commits, and releases are fully automated by
+[python-semantic-release](https://python-semantic-release.readthedocs.io/) — see
+`[tool.semantic_release]` in `pyproject.toml` and `.github/workflows/release.yaml`.
+
+That means commit messages directly determine the released version, so they are
+not cosmetic:
+
+- `fix:` → patch release
+- `feat:` → minor release
+- a `BREAKING CHANGE:` footer (or `!` after the type) → major release
+
+The version is written back to `pyproject.toml` and to `__VERSION__` in
+`netbox_prometheus_sd/__init__.py` by the release job — don't bump either by hand.
+Branches matching `pre/*` publish prereleases.

--- a/netbox_prometheus_sd/__init__.py
+++ b/netbox_prometheus_sd/__init__.py
@@ -1,8 +1,4 @@
-try:
-    from netbox.plugins import PluginConfig
-except ImportError:
-    # Fallback for old NetBox versions < 4.0
-    from extras.plugins import PluginConfig
+from netbox.plugins import PluginConfig
 
 # Placeholder for semantic release
 __VERSION__ = "1.3.0"
@@ -20,6 +16,7 @@ class PrometheusSD(PluginConfig):
     base_url = "prometheus-sd"
     required_settings = []
     default_settings = {}
+    min_version = "4.0.0"
 
 
 config = PrometheusSD

--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -1,3 +1,5 @@
+from django.contrib.contenttypes.prefetch import GenericPrefetch
+
 from ipam.models import IPAddress, Service
 from virtualization.models import VirtualMachine
 from dcim.models.devices import Device
@@ -8,16 +10,9 @@ from rest_framework.mixins import ListModelMixin
 
 from .utils import NETBOX_RELEASE_CURRENT, NETBOX_RELEASE_41
 
-# Filtersets have been renamed, we support both
-# https://github.com/netbox-community/netbox/commit/1024782b9e0abb48f6da65f8248741227d53dbed#diff-d9224204dab475bbe888868c02235b8ef10f07c9201c45c90804d395dc161c40
-try:
-    from ipam.filtersets import IPAddressFilterSet
-    from dcim.filtersets import DeviceFilterSet
-    from virtualization.filtersets import VirtualMachineFilterSet
-except ImportError:
-    from ipam.filters import IPAddressFilterSet
-    from dcim.filters import DeviceFilterSet
-    from virtualization.filters import VirtualMachineFilterSet
+from ipam.filtersets import IPAddressFilterSet
+from dcim.filtersets import DeviceFilterSet
+from virtualization.filtersets import VirtualMachineFilterSet
 
 from ..filtersets import ServiceFilterSet
 from .serializers import (
@@ -33,33 +28,90 @@ class NetboxPrometheusSDModelViewSet(CustomFieldsMixin, ListModelMixin, BaseView
     pass
 
 
+# Netbox 4.2 replaced the direct Cluster.site FK with a generic `scope` relation.
+# It stays in prefetch_related either way: a GenericForeignKey cannot be JOINed
+# via select_related.
+if NETBOX_RELEASE_CURRENT > NETBOX_RELEASE_41:
+    CLUSTER_SCOPE = "cluster__scope"
+else:
+    CLUSTER_SCOPE = "cluster__site"
+
+# Netbox 4.3 replaced Service.device/Service.virtual_machine with a single
+# generic `parent` relation, exposed via parent_object_type/parent_object_id.
+# Note: hasattr(Service, "device") is NOT a usable check — Device and
+# VirtualMachine declare `services = GenericRelation(..., related_query_name=...)`,
+# which makes Service.device resolve to a read-only reverse accessor on every
+# Netbox version, including 4.3+.
+SERVICE_HAS_GENERIC_PARENT = hasattr(Service, "parent_object_type")
+
+# Relations read off `obj.cluster` by utils.extract_cluster(), and off
+# `obj.contacts` by utils.extract_contacts(). Shared by the device and VM
+# querysets, which run the same extractors.
+CLUSTER_RELATED = ("cluster", "cluster__group", "cluster__type")
+CONTACTS_RELATED = ("contacts__contact", "contacts__role")
+
+
 class ServiceViewSet(NetboxPrometheusSDModelViewSet):
-    queryset = Service.objects.prefetch_related(
-        "device",
-        "virtual_machine",
-        "ipaddresses",
-        "tags",
+    # utils.extract_parent() walks the service's parent device/VM and pulls its
+    # name, IPs, tenant, cluster and contacts, so the parent's own relations have
+    # to be fetched too or every service row re-queries them.
+    _parent_related = (
+        "tenant__group",
+        "primary_ip4",
+        "primary_ip6",
+        "site",
+        *CLUSTER_RELATED,
+        CLUSTER_SCOPE,
+        *CONTACTS_RELATED,
     )
+
+    if SERVICE_HAS_GENERIC_PARENT:  # Netbox >= 4.3
+        queryset = Service.objects.prefetch_related(
+            GenericPrefetch(
+                "parent",
+                [
+                    Device.objects.prefetch_related(*_parent_related, "oob_ip"),
+                    VirtualMachine.objects.prefetch_related(*_parent_related),
+                ],
+            ),
+            "ipaddresses",
+            "tags",
+        )
+    else:  # Netbox < 4.3
+        queryset = Service.objects.prefetch_related(
+            *(f"device__{rel}" for rel in _parent_related),
+            "device__oob_ip",
+            *(f"virtual_machine__{rel}" for rel in _parent_related),
+            "device",
+            "virtual_machine",
+            "ipaddresses",
+            "tags",
+        )
     filterset_class = ServiceFilterSet
     serializer_class = PrometheusServiceSerializer
     pagination_class = None
 
 
 class VirtualMachineViewSet(NetboxPrometheusSDModelViewSet):
-    if NETBOX_RELEASE_CURRENT > NETBOX_RELEASE_41:
-        cluster_scope = "cluster__scope"
-    else:
-        cluster_scope = "cluster__site"
-    queryset = VirtualMachine.objects.prefetch_related(
-        cluster_scope,
-        "role",
-        "tenant",
-        "platform",
-        "primary_ip4",
-        "primary_ip6",
-        "tags",
-        "services",
-        "contacts",
+    queryset = (
+        VirtualMachine.objects.select_related(
+            "role",
+            "tenant__group",
+            "platform",
+            "primary_ip4",
+            "primary_ip6",
+            # utils.extract_cluster() falls through to obj.site for anything that
+            # has one, and VMs do on every supported Netbox release.
+            "site",
+        )
+        .prefetch_related(
+            CLUSTER_SCOPE,
+            *CLUSTER_RELATED,
+            *CONTACTS_RELATED,
+            "tags",
+            "services",
+        )
+        .annotate_config_context_data()
     )
     filterset_class = VirtualMachineFilterSet
     serializer_class = PrometheusVirtualMachineSerializer
@@ -67,19 +119,27 @@ class VirtualMachineViewSet(NetboxPrometheusSDModelViewSet):
 
 
 class DeviceViewSet(NetboxPrometheusSDModelViewSet):
-    queryset = Device.objects.prefetch_related(
-        "device_type__manufacturer",
-        "role" if hasattr(Device, "role") else "device_role",
-        "tenant",
-        "platform",
-        "site",
-        "location",
-        "rack",
-        "parent_bay",
-        "virtual_chassis__master",
-        "primary_ip4__nat_outside",
-        "primary_ip6__nat_outside",
-        "tags",
+    queryset = (
+        Device.objects.select_related(
+            "device_type",
+            "role",
+            "tenant__group",
+            "platform",
+            "site",
+            "location",
+            "rack",
+            "primary_ip4",
+            "primary_ip6",
+            "oob_ip",
+        )
+        .prefetch_related(
+            CLUSTER_SCOPE,
+            *CLUSTER_RELATED,
+            *CONTACTS_RELATED,
+            "tags",
+            "services",
+        )
+        .annotate_config_context_data()
     )
     filterset_class = DeviceFilterSet
     serializer_class = PrometheusDeviceSerializer
@@ -87,7 +147,7 @@ class DeviceViewSet(NetboxPrometheusSDModelViewSet):
 
 
 class IPAddressViewSet(NetboxPrometheusSDModelViewSet):
-    queryset = IPAddress.objects.prefetch_related("tenant", "tags")
+    queryset = IPAddress.objects.select_related("tenant__group").prefetch_related("tags")
     serializer_class = PrometheusIPAddressSerializer
     filterset_class = IPAddressFilterSet
     pagination_class = None

--- a/netbox_prometheus_sd/filtersets.py
+++ b/netbox_prometheus_sd/filtersets.py
@@ -1,5 +1,3 @@
-# Filtersets have been renamed, we support both
-# https://github.com/netbox-community/netbox/commit/1024782b9e0abb48f6da65f8248741227d53dbed#diff-d9224204dab475bbe888868c02235b8ef10f07c9201c45c90804d395dc161c40
 from django.db.models import Q
 from django.utils.translation import gettext as _
 
@@ -9,10 +7,7 @@ from utilities.filters import (
     NumericArrayFilter,
 )
 
-try:
-    from ipam.filtersets import ServiceFilterSet as NetboxServiceFilterSet
-except ImportError:
-    from ipam.filters import ServiceFilterSet as NetboxServiceFilterSet
+from ipam.filtersets import ServiceFilterSet as NetboxServiceFilterSet
 
 
 class ServiceFilterSet(NetboxServiceFilterSet):

--- a/netbox_prometheus_sd/tests/test_api.py
+++ b/netbox_prometheus_sd/tests/test_api.py
@@ -1,16 +1,11 @@
 import json
 
-try:
-    from users.models import ObjectPermission
-    from users.models import User
-    from core.models import ObjectType
+from users.models import ObjectPermission, User
+from core.models import ObjectType
 
-except ImportError:
-    # Fallback for old NetBox versions < 4.0
-    from django.contrib.contenttypes.models import ContentType as ObjectType
-    from django.contrib.auth.models import User
-
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 
 from rest_framework.test import APIClient
 from rest_framework import status
@@ -18,8 +13,8 @@ from rest_framework import status
 from . import utils
 
 
-class ApiEndpointTests(TestCase):
-    """Test cases for ensuring API endpoint is working properly."""
+class AuthenticatedApiTestCase(TestCase):
+    """Base class providing an API client authenticated with view permissions."""
 
     def setUp(self):
 
@@ -43,6 +38,10 @@ class ApiEndpointTests(TestCase):
             ObjectType.objects.get(app_label="virtualization", model="virtualmachine")
         )
         self.client.force_authenticate(user)
+
+
+class ApiEndpointTests(AuthenticatedApiTestCase):
+    """Test cases for ensuring API endpoint is working properly."""
 
     def test_endpoint_device(self):
         """Ensure device endpoint returns a valid response"""
@@ -100,3 +99,64 @@ class ApiEndpointTests(TestCase):
         self.assertIsNotNone(data[0]["targets"])
         self.assertIsNotNone(data[0]["labels"])
         self.assertEqual(len(data), 60)
+
+
+class ApiQueryCountTests(AuthenticatedApiTestCase):
+    """Regression tests for the N+1 queries reported in issue #265.
+
+    These endpoints are unpaginated, so a relation that is read by a serializer
+    but not prefetched costs one query per row. Rather than assert an exact
+    query count (which legitimately shifts between Netbox releases), assert that
+    the count does not grow when the number of objects grows -- that is the
+    property an N+1 breaks.
+    """
+
+    def assertQueryCountDoesNotScale(self, url, build, first=5, second=15):
+        for i in range(1, first + 1):
+            build(i)
+
+        # Warm up caches (content types, permissions) that are populated on the
+        # first request and would otherwise be counted only in the small run.
+        self.assertEqual(self.client.get(url).status_code, status.HTTP_200_OK)
+
+        with CaptureQueriesContext(connection) as few_objects:
+            self.assertEqual(self.client.get(url).status_code, status.HTTP_200_OK)
+
+        for i in range(first + 1, second + 1):
+            build(i)
+
+        with CaptureQueriesContext(connection) as many_objects:
+            self.assertEqual(self.client.get(url).status_code, status.HTTP_200_OK)
+
+        self.assertEqual(
+            len(few_objects),
+            len(many_objects),
+            f"Query count for {url} grew from {len(few_objects)} queries with "
+            f"{first} objects to {len(many_objects)} with {second}. A relation "
+            f"used by the serializer is likely missing from the queryset in "
+            f"api/views.py.",
+        )
+
+    def test_device_endpoint_query_count_does_not_scale(self):
+        self.assertQueryCountDoesNotScale(
+            "/api/plugins/prometheus-sd/devices/",
+            lambda i: utils.build_device_full(f"query-count-{i}.example.com", i),
+        )
+
+    def test_virtual_machine_endpoint_query_count_does_not_scale(self):
+        self.assertQueryCountDoesNotScale(
+            "/api/plugins/prometheus-sd/virtual-machines/",
+            lambda i: utils.build_vm_full(f"query-count-vm-{i}.example.com", i),
+        )
+
+    def test_service_endpoint_query_count_does_not_scale(self):
+        self.assertQueryCountDoesNotScale(
+            "/api/plugins/prometheus-sd/services/",
+            lambda i: utils.build_vm_full(f"query-count-svc-{i}.example.com", i),
+        )
+
+    def test_ip_address_endpoint_query_count_does_not_scale(self):
+        self.assertQueryCountDoesNotScale(
+            "/api/plugins/prometheus-sd/ip-addresses/",
+            lambda i: utils.build_full_ip(address=f"10.10.20.{i}/24"),
+        )

--- a/netbox_prometheus_sd/tests/test_api.py
+++ b/netbox_prometheus_sd/tests/test_api.py
@@ -57,6 +57,15 @@ class ApiEndpointTests(AuthenticatedApiTestCase):
         self.assertIsNotNone(data[0]["labels"])
         self.assertEqual(len(data), 60)
 
+        # Serializer tests render the in-memory fixture object, so they cannot
+        # catch a fixture that sets an attribute without persisting it. Assert
+        # these here, where the objects come back out of the database.
+        labels = {d["labels"]["__meta_netbox_name"]: d["labels"] for d in data}
+        first = labels["api-test-1.example.com"]
+        self.assertEqual(first.get("__meta_netbox_rack_u_position"), "1.0")
+        self.assertEqual(first.get("__meta_netbox_contact_primary_name"), "Jane Doe")
+        self.assertEqual(first.get("__meta_netbox_contact_primary_role"), "On Call")
+
     def test_endpoint_virtual_machine(self):
         """Ensure virtual machine endpoint returns a valid response"""
 
@@ -71,6 +80,11 @@ class ApiEndpointTests(AuthenticatedApiTestCase):
         self.assertIsNotNone(data[0]["labels"])
         # Full vm contains two entry in the config context so we have to double the number of vm
         self.assertEqual(len(data), 120)
+
+        labels = {d["labels"]["__meta_netbox_name"]: d["labels"] for d in data}
+        first = labels["api-test-vm-1.example.com"]
+        self.assertEqual(first.get("__meta_netbox_contact_primary_name"), "Jane Doe")
+        self.assertEqual(first.get("__meta_netbox_contact_primary_role"), "On Call")
 
     def test_endpoint_ip_address(self):
         """Ensure ip address endpoint returns a valid response"""

--- a/netbox_prometheus_sd/tests/test_serializers.py
+++ b/netbox_prometheus_sd/tests/test_serializers.py
@@ -198,6 +198,32 @@ class PrometheusVirtualMachineSerializerTests(TestCase):
                     data["labels"],
                 )
             )
+            # Tags are compared as sets: the label is a joined list whose order
+            # is not guaranteed.
+            self.assertEqual(
+                set(data["labels"]["__meta_netbox_tags"].split(",")),
+                {"Tag1", "Tag 2"},
+            )
+            self.assertEqual(
+                set(data["labels"]["__meta_netbox_tag_slugs"].split(",")),
+                {"tag1", "tag-2"},
+            )
+            self.assertTrue(
+                utils.dictContainsSubset(
+                    {"__meta_netbox_services": "ssh"}, data["labels"]
+                )
+            )
+            self.assertTrue(
+                utils.dictContainsSubset(
+                    {
+                        "__meta_netbox_contact_primary_name": "Jane Doe",
+                        "__meta_netbox_contact_primary_email": "jane@example.com",
+                        "__meta_netbox_contact_primary_comments": "Primary on-call",
+                        "__meta_netbox_contact_primary_role": "On Call",
+                    },
+                    data["labels"],
+                )
+            )
 
 
 class PrometheusDeviceSerializerTests(TestCase):
@@ -356,6 +382,29 @@ class PrometheusDeviceSerializerTests(TestCase):
                 {"__meta_netbox_rack_u_position": "1.0"}, data["labels"]
             )
         )
+        # Tags are compared as sets: the label is a joined list whose order is
+        # not guaranteed.
+        self.assertEqual(
+            set(data["labels"]["__meta_netbox_tags"].split(",")), {"Tag1", "Tag 2"}
+        )
+        self.assertEqual(
+            set(data["labels"]["__meta_netbox_tag_slugs"].split(",")),
+            {"tag1", "tag-2"},
+        )
+        self.assertTrue(
+            utils.dictContainsSubset({"__meta_netbox_services": "ssh"}, data["labels"])
+        )
+        self.assertTrue(
+            utils.dictContainsSubset(
+                {
+                    "__meta_netbox_contact_primary_name": "Jane Doe",
+                    "__meta_netbox_contact_primary_email": "jane@example.com",
+                    "__meta_netbox_contact_primary_comments": "Primary on-call",
+                    "__meta_netbox_contact_primary_role": "On Call",
+                },
+                data["labels"],
+            )
+        )
 
 
 class PrometheusIPAddressSerializerTests(TestCase):
@@ -493,6 +542,11 @@ class PrometheusServiceSerializerTests(TestCase):
                     {"__meta_netbox_primary_ip6": "2001:db8:1701::2"}, data["labels"]
                 )
             )
+            self.assertTrue(
+                utils.dictContainsSubset(
+                    {"__meta_netbox_ipaddresses": "192.168.0.1"}, data["labels"]
+                )
+            )
 
     def test_vm_service_full_to_target(self):
         vm = utils.build_vm_full("vm-full-01.example.com")
@@ -574,5 +628,10 @@ class PrometheusServiceSerializerTests(TestCase):
             self.assertTrue(
                 utils.dictContainsSubset(
                     {"__meta_netbox_primary_ip6": "2001:db8:1701::2"}, data["labels"]
+                )
+            )
+            self.assertTrue(
+                utils.dictContainsSubset(
+                    {"__meta_netbox_ipaddresses": "192.168.0.1"}, data["labels"]
                 )
             )

--- a/netbox_prometheus_sd/tests/utils.py
+++ b/netbox_prometheus_sd/tests/utils.py
@@ -122,7 +122,6 @@ def build_vm_full(name, ip_octet=1):
 
 
 def build_minimal_device(name):
-    role_attr = "role" if hasattr(Device, "role") else "device_role"
     return Device.objects.get_or_create(
         name=name,
         device_type=DeviceType.objects.get_or_create(
@@ -133,11 +132,7 @@ def build_minimal_device(name):
             )[0],
         )[0],
         site=Site.objects.get_or_create(name="Site", slug="site")[0],
-        **{
-            role_attr: DeviceRole.objects.get_or_create(
-                name="Firewall", slug="firewall"
-            )[0],
-        },
+        role=DeviceRole.objects.get_or_create(name="Firewall", slug="firewall")[0],
     )[0]
 
 

--- a/netbox_prometheus_sd/tests/utils.py
+++ b/netbox_prometheus_sd/tests/utils.py
@@ -133,11 +133,25 @@ def build_vm_full(name, ip_octet=1):
     vm.save()
 
     build_contact_for(vm)
-    try: # NetBox 4.2+
-        Service.objects.create(parent=vm, name="ssh", protocol="tcp", ports=[22])
-    except AttributeError: # NetBox <4.2
-        Service.objects.create(virtual_machine=vm, name="ssh", protocol="tcp", ports=[22])
+    build_service_for(vm, name="ssh", protocol="tcp", ports=[22])
     return vm
+
+
+def build_service_for(parent, **kwargs):
+    """Create a service bound to parent, with the parent's primary IPv4 attached.
+
+    Netbox 4.3 replaced Service.device/Service.virtual_machine with a single
+    generic `parent` relation, which is read-only on older releases.
+    """
+    try: # NetBox 4.3+
+        service = Service.objects.create(parent=parent, **kwargs)
+    except AttributeError: # NetBox <4.3
+        field = "device" if isinstance(parent, Device) else "virtual_machine"
+        service = Service.objects.create(**{field: parent}, **kwargs)
+
+    if parent.primary_ip4 is not None:
+        service.ipaddresses.set([parent.primary_ip4])
+    return service
 
 
 def build_minimal_device(name):
@@ -252,10 +266,7 @@ def build_device_full(name, ip_octet=1):
     device.tags.add("Tag 2")
     device.save()
     build_contact_for(device)
-    try: # NetBox 4.2+
-        Service.objects.create(parent=device, name="ssh", protocol="tcp", ports=[22])
-    except AttributeError: # NetBox <4.2
-        Service.objects.create(device=device, name="ssh", protocol="tcp", ports=[22])
+    build_service_for(device, name="ssh", protocol="tcp", ports=[22])
     return device
 
 

--- a/netbox_prometheus_sd/tests/utils.py
+++ b/netbox_prometheus_sd/tests/utils.py
@@ -7,7 +7,13 @@ from dcim.models import Device, DeviceRole, Platform, Rack
 from extras.models import ConfigContext, Tag
 
 from ipam.models import IPAddress, Service
-from tenancy.models import Tenant, TenantGroup
+from tenancy.models import (
+    Contact,
+    ContactAssignment,
+    ContactRole,
+    Tenant,
+    TenantGroup,
+)
 
 from virtualization.models import (
     Cluster,
@@ -51,6 +57,18 @@ def build_location():
 
 def build_tenant():
     return Tenant.objects.get_or_create(name="Acme Corp.", slug="acme")[0]
+
+
+def build_contact_for(obj):
+    """Assign a contact to obj so extract_contacts() has something to render."""
+    contact = Contact.objects.get_or_create(
+        name="Jane Doe",
+        defaults={"email": "jane@example.com", "comments": "Primary on-call"},
+    )[0]
+    role = ContactRole.objects.get_or_create(name="On Call", slug="on-call")[0]
+    return ContactAssignment.objects.create(
+        object=obj, contact=contact, role=role, priority="primary"
+    )
 
 
 def build_custom_fields():
@@ -114,6 +132,7 @@ def build_vm_full(name, ip_octet=1):
     vm.tags.add("Tag 2")
     vm.save()
 
+    build_contact_for(vm)
     try: # NetBox 4.2+
         Service.objects.create(parent=vm, name="ssh", protocol="tcp", ports=[22])
     except AttributeError: # NetBox <4.2
@@ -220,13 +239,19 @@ def build_device_full(name, ip_octet=1):
     )[0]
     device.oob_ip = IPAddress.objects.get_or_create(address=f"10.0.0.{ip_octet}/24")[0]
     device.rack = Rack.objects.get_or_create(
-        name="R01B01", site=Site.objects.get_or_create(name="Site", slug="site")[0]
+        name="R01B01",
+        site=Site.objects.get_or_create(name="Site", slug="site")[0],
+        defaults={"u_height": 100},
     )[0]
     device.site = Site.objects.get_or_create(name="Site", slug="site")[0]
+    # Rack position is unique per (rack, position, face), so it has to follow
+    # ip_octet like the addresses do -- otherwise callers building more than one
+    # device hit an IntegrityError.
+    device.position = float(ip_octet)
     device.tags.add("Tag1")
     device.tags.add("Tag 2")
     device.save()
-    device.position = 1.0
+    build_contact_for(device)
     try: # NetBox 4.2+
         Service.objects.create(parent=device, name="ssh", protocol="tcp", ports=[22])
     except AttributeError: # NetBox <4.2


### PR DESCRIPTION
Fixes #265.

## What was wrong

The SD endpoints are unpaginated, so one request serializes the entire
inventory. Any relation a serializer reads but the queryset does not fetch
costs a query *per row*. Three separate causes, all per-row:

1. **Config context.** `get_config_context()` is called for every row by
   `SDConfigContextDuplicateSerializer` and queries each time unless the
   queryset is annotated. The device and VM querysets now call
   `.annotate_config_context_data()`.
2. **Missing relations.** Cluster (plus group/type/scope), services, contacts
   and `oob_ip` on devices, and the tenant group everywhere, were read by the
   serializers but never fetched.
3. **A subtle one.** `utils.extract_cluster()` ends with a catch-all `obj.site`
   lookup commented *"Still Return site labels for Devices"* — but virtual
   machines carry a `site` FK too on every supported 4.x release. Every VM row
   hit the database for it, and so did every service row via `extract_parent()`.
   Found by capturing the SQL: one `dcim_site` SELECT per VM.

Single-valued FKs move to `select_related` (JOIN instead of a second query).
Generic relations (`cluster__scope`, and `Service.parent` on 4.3+) can't be
JOINed and stay in `prefetch_related`; the service queryset uses
`GenericPrefetch` on 4.3+. Prefetches nothing reads are dropped
(`device_type__manufacturer`, `parent_bay`, `virtual_chassis__master`,
`__nat_outside`).

> **Gotcha for future work:** `hasattr(Service, "device")` is **always** true and
> cannot detect the 4.3 generic-parent change — Device and VirtualMachine declare
> `services = GenericRelation(..., related_query_name=...)`, so `Service.device`
> resolves to a read-only reverse accessor on every version. The check is
> `hasattr(Service, "parent_object_type")`.

## Regression tests

The new tests assert that **query count does not grow with object count**, rather
than pinning an exact number that would drift between Netbox releases.

Verified they have teeth: against the previous querysets the device, VM and
service tests all fail (the VM endpoint went from 25 queries at 5 objects to 45
at 15), and pass with this change.

## Test gaps found along the way

Auditing every emitted label against what the suite asserts turned up several
things that were never covered, plus two latent fixture bugs:

- `build_device_full()` set `device.position` **after** `device.save()`, so the
  rack position was never persisted. The serializer test asserting
  `rack_u_position == "1.0"` passed anyway, because serializer tests render the
  in-memory fixture object. Confirmed by reverting the ordering with the new
  API-level assertion in place: the label disappears entirely.
- Persisting it exposed a second bug hidden behind the first — all 60 devices in
  the loops claimed rack position 1.0, violating the unique constraint on
  `(rack, position, face)` once the value actually reached the database.
- `tags` / `tag_slugs` were never asserted, despite every fixture adding tags.
- `services`, `ipaddresses`, and contact `email`/`comments` had no coverage;
  services were created without IPs, leaving `extract_service_ips()` dead in tests.
- No `ContactAssignment` existed anywhere, so `extract_contacts()` was untested.

New assertions that guard persistence live in the API tests, since that is the
layer that reads objects back out of the database.

## Netbox 3.x cleanup

The 3.x cut was started earlier but left unreachable fallbacks behind
(`extras.plugins`, `ipam.filters`, `Device.device_role`). Those are removed, and
`min_version = "4.0.0"` is declared so an install on an unsupported Netbox fails
fast instead of surfacing as an obscure `AttributeError` at request time.

This commit is marked `refactor!` — semantic-release will treat it as a major
version bump. Happy to soften it to a plain `refactor:` if you'd rather keep this
in the 1.x line, since 1.3.0 already declared 4.0+ support.

## Verification

Full suite run against real Netbox containers, both sides of the 4.2 cluster-scope
change and the 4.3 service-parent change:

| Netbox | Result |
|---|---|
| 4.0.11 | 27/27 |
| 4.2.9  | 27/27 |
| 4.3.7  | 27/27 |
| 4.5.2  | 27/27 |
| 4.6.5  | 27/27 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)