### PR TITLE
ci: auto-merge non-critical Dependabot updates once CI is green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,26 @@ jobs:
         env:
           NETBOX_VER: ${{ matrix.netbox-version }}
           DOCKER_FLAGS: "--cache-from=type=gha --cache-to=type=gha,mode=max"
+
+  # Single aggregated status check for branch protection to require.
+  #
+  # Requiring the matrix jobs directly would mean editing branch protection
+  # every time the Netbox version list changes, and a required check that no
+  # longer exists blocks every PR forever. Requiring only this job keeps that
+  # list free to change.
+  #
+  # `always()` is load-bearing: without it this job is skipped when anything it
+  # needs fails, the check never reports, and PRs wait on it indefinitely.
+  ci-ok:
+    if: always()
+    needs: [commitlint, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify that all jobs passed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "commitlint: ${{ needs.commitlint.result }}"
+          echo "build:      ${{ needs.build.result }}"
+          exit 1
+      - name: All checks passed
+        run: echo "commitlint and the full Netbox matrix are green."

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,99 @@
+name: Dependabot auto-merge
+
+# `pull_request_target` runs the workflow definition from the base branch with a
+# writable token, which is what lets it act on Dependabot's PRs (Dependabot's own
+# `pull_request` runs only ever get a read-only token).
+#
+# This is only safe because nothing below checks out or executes the PR's code --
+# it just reads metadata and asks GitHub to queue the merge. Do not add a
+# checkout of `github.event.pull_request.head` to this file.
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Development tooling may auto-merge at any version: a broken dev
+      # dependency surfaces as a red pipeline, not as a broken release. Anything
+      # shipped to users -- currently the Netbox base image -- is held to patch
+      # and minor.
+      #
+      # The ecosystem allowances are opt-in by name rather than derived from
+      # `dependency-type`, so an ecosystem we have not considered falls through
+      # to the patch/minor rule instead of being treated as safe by accident.
+      - name: Apply auto-merge policy
+        id: policy
+        env:
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          DEP_TYPE: ${{ steps.metadata.outputs.dependency-type }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        run: |
+          set -euo pipefail
+          merge=false
+          reason="major update to a shipped dependency"
+
+          case "$ECOSYSTEM" in
+            github_actions|github-actions)
+              merge=true
+              reason="CI tooling, not shipped to users"
+              ;;
+            pip)
+              if [ "$DEP_TYPE" = "direct:development" ]; then
+                merge=true
+                reason="development-only dependency"
+              fi
+              ;;
+          esac
+
+          if [ "$merge" = "false" ]; then
+            case "$UPDATE_TYPE" in
+              version-update:semver-patch|version-update:semver-minor)
+                merge=true
+                reason="non-major update"
+                ;;
+            esac
+          fi
+
+          {
+            echo "merge=$merge"
+            echo "reason=$reason"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Dependabot auto-merge"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Dependencies | ${{ steps.metadata.outputs.dependency-names }} |"
+            echo "| Ecosystem | \`$ECOSYSTEM\` |"
+            echo "| Dependency type | \`$DEP_TYPE\` |"
+            echo "| Update type | \`$UPDATE_TYPE\` |"
+            echo "| Auto-merge | **$merge** ($reason) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Queues the merge only; GitHub still holds the PR until the required
+      # `ci-ok` check passes, so a bump that breaks the matrix never lands.
+      - name: Queue auto-merge
+        if: steps.policy.outputs.merge == 'true'
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Leave a note for the maintainer
+        if: steps.policy.outputs.merge != 'true'
+        run: |
+          gh pr comment "${{ github.event.pull_request.html_url }}" --body \
+            "Not auto-merged: ${{ steps.policy.outputs.reason }}. This one needs a human review before merging."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Queues Dependabot PRs for merge automatically when the pipeline is green, while
keeping the updates that genuinely warrant a look.

## The sharp edge worth knowing about

Branch protection on `main` currently requires **zero** status checks. Enabling
auto-merge on its own would therefore have merged Dependabot PRs *instantly* —
there is nothing for GitHub to wait on — which is the opposite of the goal.

So the gate is the branch protection rule, not the workflow. Sequencing matters:

- [x] `allow_auto_merge` enabled on the repo (was `false`)
- [x] `ci-ok` aggregate job added (this PR)
- [ ] **After this merges:** add `ci-ok` as a required status check on `main`

That last step is deliberately not done yet — `ci-ok` does not exist on `main`
until this lands, and requiring a check that never reports blocks every PR
forever.

## Policy

Development tooling may auto-merge at any version, since a bad dev dependency
shows up as a red pipeline rather than a broken release. Anything shipped to
users — currently the Netbox base image — is held to patch and minor.

| Update | Auto-merge |
|---|---|
| GitHub Actions, any version | yes |
| pip `direct:development`, any version | yes |
| Netbox image / any runtime dep, patch or minor | yes |
| Netbox image / any runtime dep, **major** | no — comments on the PR |
| Unrecognised ecosystem, major | no |

Ecosystems are allowed **by name** rather than derived from `dependency-type`,
so an ecosystem nobody has considered yet falls through to the patch/minor rule
instead of being treated as safe by accident. Verified against the real metadata
combinations, including the fail-safe cases:

```
actions/checkout v4->v7 (major)      -> merge=true   (CI tooling)
testcontainers 4->5 (dev major)      -> merge=true   (development-only)
netbox image 4.5->4.6 (minor)        -> merge=true   (non-major)
netbox image 4->5 (MAJOR runtime)    -> merge=false
future runtime pip dep (major)       -> merge=false
unknown ecosystem (major)            -> merge=false
docker misclassified as dev (major)  -> merge=false
```

## `ci-ok`

A single aggregate check that passes only if commitlint and the whole Netbox
matrix pass. Branch protection requires just this one, so the matrix stays free
to change — naming the matrix jobs directly would mean editing protection on
every Netbox version bump, and a stale required check blocks everything.

Its `if: always()` is load-bearing: without it the job is skipped whenever a
dependency fails, the check never reports, and PRs wait forever.

## Security note

The workflow uses `pull_request_target` because Dependabot's own `pull_request`
runs only ever get a read-only token. That trigger is safe **only** because this
workflow never checks out or executes the PR's code — it reads metadata and asks
GitHub to queue the merge. There's a comment in the file saying so; please keep a
checkout of `head` out of it.

## One residual gap

CI exercises `ci.yml` only. A major bump to an action used solely in
`release.yaml` or `publish.yml` would auto-merge on green CI without those paths
ever being run. That follows from treating Actions as dev tooling; if you'd
rather, I can exclude majors for the release actions specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)