### PR TITLE
fix: only upload release artifacts when a release was cut

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,8 +52,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
 
+      # Only a released commit produces `dist/`: semantic-release runs
+      # `build_command` when it cuts a version, and skips it otherwise. Without
+      # this guard the step runs on every push, finds no `dist/`, and fails on
+      # `if-no-files-found: error` -- which is why every `chore:`/`ci:` commit
+      # (Dependabot's included) has been failing this workflow.
       - name: Upload | Distribution Artifacts
         uses: actions/upload-artifact@v7
+        if: steps.release.outputs.released == 'true'
         with:
           name: distribution-artifacts
           path: dist


### PR DESCRIPTION
The release workflow has been failing on every push that does not produce a
version — including all seven Dependabot merges from today.

## Cause

`dist/` only exists when semantic-release actually cuts a release: `build_command`
(`pip install poetry && poetry build`) runs as part of publishing and is skipped
otherwise. On a `chore:`/`ci:` commit no version is produced, so no `dist/` is
built — but the artifact upload ran anyway and failed on `if-no-files-found: error`:

```
##[error]No files were found with the provided path: dist. No artifacts will be uploaded.
```

The step immediately above it, `Publish | Upload to GitHub Release Assets`,
already had the correct `if: steps.release.outputs.released == 'true'` guard.
This one was just missing it.

## Evidence

The run history splits perfectly along "did this commit cut a version":

| Commit | Released | Result |
|---|---|---|
| `test: assert tags…` (cut v2.0.0) | yes | pass |
| `ci: adjust release branch` | yes | pass |
| 13 × `chore(deps): …` since March | **no** | **fail** |

## Why now

Not a new regression — it dates to at least 2026-03-30. But auto-merge means
`chore(deps)` commits now land without anyone watching, so this fires on
essentially every dependency update instead of occasionally. A release pipeline
that is permanently red is one nobody reads on the day it goes red for a real
reason.

## Verification

The workflow only runs on push to `main`, so it cannot be exercised from a PR.
What I checked instead:

- YAML parses, and both upload steps now carry the identical guard.
- `steps.release.outputs.released` is already consumed by the job's own `outputs:`
  block, so the expression is known-good rather than newly invented.

After this merges, the release run for this very commit is the real test: it is a
`fix:`, so it *should* cut a patch release, build `dist/`, and upload — exercising
the true branch. The false branch is then covered by the next `chore(deps)` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)