### PR TITLE
ci: lint workflow files with actionlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,16 @@ jobs:
       - uses: actions/checkout@v7
       - uses: wagoid/commitlint-github-action@v6
 
+  # Static analysis of the workflow files themselves, including shellcheck over
+  # `run:` blocks. Worth having because CI never executes release.yaml or
+  # publish.yml -- a mistake in either only shows up when a release is cut.
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Lint workflow files
+        uses: docker://rhysd/actionlint:1.7.12
+
   # Matrix build for Netbox versions
   build:
     runs-on: ubuntu-latest
@@ -90,14 +100,15 @@ jobs:
   # needs fails, the check never reports, and PRs wait on it indefinitely.
   ci-ok:
     if: always()
-    needs: [commitlint, build]
+    needs: [commitlint, actionlint, build]
     runs-on: ubuntu-latest
     steps:
       - name: Verify that all jobs passed
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "commitlint: ${{ needs.commitlint.result }}"
+          echo "actionlint: ${{ needs.actionlint.result }}"
           echo "build:      ${{ needs.build.result }}"
           exit 1
       - name: All checks passed
-        run: echo "commitlint and the full Netbox matrix are green."
+        run: echo "commitlint, actionlint and the full Netbox matrix are green."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,6 @@ jobs:
           pip install poetry
       - name: Build and publish
         run: |
-          poetry version $(git describe --tags --abbrev=0)
+          poetry version "$(git describe --tags --abbrev=0)"
           poetry build
           poetry publish --username __token__ --password ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
CI runs the test matrix but never executes `release.yaml` or `publish.yml`, so a
mistake in either only surfaces when a release is cut — which is how the
artifact-upload bug in #276 survived since March. This gives those files a static
check, including shellcheck over `run:` blocks.

Wired into `ci-ok`, so branch protection covers it without another required check.

## Found one real issue

`publish.yml` had an unquoted command substitution (SC2046), fixed here.

## Verified in both directions

Not just "added a job and it went green":

| Tree | actionlint |
|---|---|
| as it stands | exit 0, clean |
| with a deliberately broken job injected | exit 1 |

The injected errors it caught — an undefined `github.*` context and an unknown
action input:

```
ci.yml:122:24: property "no_such_context" is not defined in object type {...} [expression]
```

## Honest limitation

**This would not have caught #276.** That YAML was always valid; the logic was
wrong (a missing `if:` guard). actionlint covers a different class of mistake —
typos, undefined contexts, bad inputs, shell quoting. Worth having, but it is not
a substitute for exercising the release path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)