### PR TITLE
fix: publish releases to PyPI from the release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,16 @@ jobs:
       - uses: actions/checkout@v7
       - uses: wagoid/commitlint-github-action@v6
 
+  # Static analysis of the workflow files themselves, including shellcheck over
+  # `run:` blocks. Worth having because CI never executes release.yaml or
+  # publish.yml -- a mistake in either only shows up when a release is cut.
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Lint workflow files
+        uses: docker://rhysd/actionlint:1.7.12
+
   # Matrix build for Netbox versions
   build:
     runs-on: ubuntu-latest
@@ -90,14 +100,15 @@ jobs:
   # needs fails, the check never reports, and PRs wait on it indefinitely.
   ci-ok:
     if: always()
-    needs: [commitlint, build]
+    needs: [commitlint, actionlint, build]
     runs-on: ubuntu-latest
     steps:
       - name: Verify that all jobs passed
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "commitlint: ${{ needs.commitlint.result }}"
+          echo "actionlint: ${{ needs.actionlint.result }}"
           echo "build:      ${{ needs.build.result }}"
           exit 1
       - name: All checks passed
-        run: echo "commitlint and the full Netbox matrix are green."
+        run: echo "commitlint, actionlint and the full Netbox matrix are green."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,6 @@ jobs:
           pip install poetry
       - name: Build and publish
         run: |
-          poetry version $(git describe --tags --abbrev=0)
+          poetry version "$(git describe --tags --abbrev=0)"
           poetry build
           poetry publish --username __token__ --password ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,20 @@
 name: Publish on PyPi
 
+# Manual fallback for publishing a tag that is not on PyPI -- a release whose
+# publish step failed, or one tagged before releases published automatically.
+#
+# Normal releases publish from release.yaml. This workflow used to trigger on
+# `push: tags: v*`, but that never fired once: semantic-release creates tags
+# using GITHUB_TOKEN, and GitHub deliberately does not start workflow runs from
+# GITHUB_TOKEN events. The trigger is gone rather than left in place looking
+# functional.
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish, e.g. v2.0.0"
+        required: true
+        type: string
 
 jobs:
   deploy:
@@ -12,17 +22,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.8"
+          python-version: "3.12"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install poetry
-      - name: Build and publish
-        run: |
-          poetry version "$(git describe --tags --abbrev=0)"
-          poetry build
-          poetry publish --username __token__ --password ${{ secrets.PYPI_PASSWORD }}
+
+      # No `poetry version` step: semantic-release already wrote the released
+      # version into pyproject.toml on the tagged commit. Deriving it instead
+      # from `git describe` set the version to "v2.0.0" -- leading "v" included,
+      # which is not a valid PEP 440 version.
+      - name: Build
+        run: poetry build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,20 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
 
+      # Publishing happens here rather than from a tag-triggered workflow.
+      # semantic-release creates the tag using GITHUB_TOKEN, and GitHub does not
+      # start workflow runs from GITHUB_TOKEN events, so a `on: push: tags:`
+      # trigger never fires -- which is why v2.0.0 was tagged and released on
+      # GitHub but never reached PyPI.
+      #
+      # `dist/` is already present: semantic-release runs `build_command` when it
+      # cuts a version, which is the same reason the artifact upload below works.
+      - name: Publish | Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: steps.release.outputs.released == 'true'
+        with:
+          password: ${{ secrets.PYPI_PASSWORD }}
+
       # Only a released commit produces `dist/`: semantic-release runs
       # `build_command` when it cuts a version, and skips it otherwise. Without
       # this guard the step runs on every push, finds no `dist/`, and fails on

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,8 +52,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
 
+      # Only a released commit produces `dist/`: semantic-release runs
+      # `build_command` when it cuts a version, and skips it otherwise. Without
+      # this guard the step runs on every push, finds no `dist/`, and fails on
+      # `if-no-files-found: error` -- which is why every `chore:`/`ci:` commit
+      # (Dependabot's included) has been failing this workflow.
       - name: Upload | Distribution Artifacts
         uses: actions/upload-artifact@v7
+        if: steps.release.outputs.released == 'true'
         with:
           name: distribution-artifacts
           path: dist


### PR DESCRIPTION
**v2.0.0 is tagged and has a GitHub Release, but `pip install` still gets 1.3.0.**
Everything from today — the #265 query fix, the 4.x cleanup — is not actually
reaching users.

> **Stacked on #276 and #277.** Merge those two first; this branch already
> contains them, so its diff collapses to just this commit once they land. All
> three compose cleanly (verified, not assumed).

## Why the tag trigger never fired

`publish.yml` triggered on `push: tags: v*`. semantic-release creates those tags
with `GITHUB_TOKEN`, and GitHub deliberately does not start workflow runs from
`GITHUB_TOKEN` events — otherwise workflows could trigger themselves. Both tags
confirm the author:

```
v1.3.0 -> github-actions <actions@users.noreply.github.com>
v2.0.0 -> github-actions <actions@users.noreply.github.com>
```

The workflow's **entire run history is one manual `workflow_dispatch` on
2026-03-17** — that is how 1.3.0 got published. Every release since has been
GitHub-only.

## Why re-running it by hand would not have worked either

```bash
poetry version $(git describe --tags --abbrev=0)
```

sets the version to the literal `v2.0.0`, leading `v` included — not a valid
PEP 440 version. Confirmed against poetry directly:

```
$ poetry version "v2.0.0"     →  version="v2.0.0"
```

The line is also redundant: semantic-release already writes the correct version
into `pyproject.toml` before tagging. It is removed.

## The fix

Publishing moves into `release.yaml`, in the same job that cuts the release,
guarded by `released == 'true'` exactly like the GitHub-assets step beside it.
No tag event is involved, so there is nothing to fail to fire. `dist/` is already
present because semantic-release runs `build_command` when it publishes — the
same reason the existing artifact upload works.

`publish.yml` stays as a manual fallback for republishing a tag, now
dispatch-only with a required `tag` input that it checks out. Its dead trigger is
removed rather than left looking functional, and `python-version` goes 3.8 → 3.12
(the project requires >= 3.10).

## Verification

Release workflows only run on push to `main`, so this cannot be exercised from a
PR. What I did check:

- actionlint clean on the **composed** tree (#276 + #277 + this).
- All three publish/upload steps now carry the identical `released == 'true'`
  guard.
- The PEP 440 problem reproduced with poetry locally.
- Tag authorship confirmed via `git log` on both tags.

## To get v2.0.0 out

After merging, run **Publish on PyPi** manually with `tag: v2.0.0`. Future
releases publish automatically.

Worth considering separately: PyPI Trusted Publishing (OIDC) would let you retire
the `PYPI_PASSWORD` secret entirely. It needs configuration on pypi.org, so I
have not assumed it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)